### PR TITLE
1.19.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
 apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'org.spongepowered.mixin'
 
-version = '0.6.0'
+version = '1.0.0'
 group = 'com.deku.cherryblossomgrotto' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'cherryblossomgrotto'
 

--- a/src/main/java/com/deku/cherryblossomgrotto/Main.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/Main.java
@@ -15,6 +15,7 @@ import com.deku.cherryblossomgrotto.common.recipes.ModRecipeSerializerInitialize
 import com.deku.cherryblossomgrotto.common.utils.ForgeReflection;
 import com.deku.cherryblossomgrotto.common.world.gen.biomes.ModBiomeInitializer;
 import com.deku.cherryblossomgrotto.common.world.gen.biomes.ModBiomeProvider;
+import com.deku.cherryblossomgrotto.common.world.gen.biomes.ModSurfaceRules;
 import com.deku.cherryblossomgrotto.common.world.gen.blockstateprovider.CherryBlossomForestFlowerProviderType;
 import com.deku.cherryblossomgrotto.common.world.gen.foliagePlacers.GrandCherryBlossomFoliagePlacerType;
 import com.deku.cherryblossomgrotto.common.world.gen.foliagePlacers.CherryBlossomFoliagePlacerType;
@@ -86,6 +87,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import terrablender.api.Regions;
+import terrablender.api.SurfaceRuleManager;
 
 import java.util.Map;
 import java.util.Optional;
@@ -190,6 +192,7 @@ public class Main
             WoodType.register(ModWoodType.CHERRY_BLOSSOM);
 
             Regions.register(new ModBiomeProvider());
+            SurfaceRuleManager.addSurfaceRules(SurfaceRuleManager.RuleCategory.OVERWORLD, MOD_ID, ModSurfaceRules.makeRules());
         });
 
         // TODO: Need to add the boat trade for the new villager type for this to work
@@ -518,7 +521,7 @@ public class Main
          */
         @SubscribeEvent
         public static void onCreativeModeTabRegister(CreativeModeTabEvent.Register creativeTabBuildRegistryEvent) {
-            creativeTabBuildRegistryEvent.registerCreativeModeTab(new ResourceLocation(MOD_ID, "cherry_blossom_grotto"), builder ->
+            creativeTabBuildRegistryEvent.registerCreativeModeTab(new ResourceLocation(MOD_ID, "cherry_blossom_grotto_creative_tab"), builder ->
                 builder.title(Component.translatable("Cherry Blossom Grotto"))
                     .icon(() -> new ItemStack(ModItems.CHERRY_SAPLING))
                     .displayItems((enabledFlags, populator, hasPermissions) -> {

--- a/src/main/java/com/deku/cherryblossomgrotto/common/features/ModVegetationFeatures.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/features/ModVegetationFeatures.java
@@ -19,11 +19,14 @@ import net.minecraft.world.level.levelgen.feature.configurations.*;
 import net.minecraft.world.level.levelgen.feature.stateproviders.BlockStateProvider;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 
+import java.util.List;
+
 import static com.deku.cherryblossomgrotto.Main.MOD_ID;
 
 public class ModVegetationFeatures {
     public static ResourceKey<ConfiguredFeature<?, ?>> TREES_CHERY_BLOSSOM_GROTTO = registerVegetationFeatureKey("trees_cherry_blossom_grotto");
     public static ResourceKey<ConfiguredFeature<?, ?>> CHERY_BLOSSOM_GROTTO_FLOWERS = registerVegetationFeatureKey("cherry_blossom_grotto_flowers");
+    public static ResourceKey<ConfiguredFeature<?, ?>> TREES_CHERY_BLOSSOM_SLOPES = registerVegetationFeatureKey("trees_cherry_blossom_slopes");
 
     /**
      * Registers a resource key for the given vegetation feature name
@@ -82,6 +85,22 @@ public class ModVegetationFeatures {
     }
 
     /**
+     * Creates a feature configuration for the sparse cherry blossom trees on slopes
+     *
+     * @param cherryBlossomTree Holder for the placeable cherry blossom trees feature
+     * @param fancyCherryBlossomTree Holder for the placeable fancy cherry blossom trees feature
+     * @return Random feature configuration for spreading the trees
+     */
+    private static RandomFeatureConfiguration createCherryBlossomSlopesTreesConfiguration(Holder<PlacedFeature> cherryBlossomTree, Holder<PlacedFeature> fancyCherryBlossomTree) {
+        return new RandomFeatureConfiguration(
+            ImmutableList.of(
+                new WeightedPlacedFeature(fancyCherryBlossomTree, 0.1f)
+            ),
+            cherryBlossomTree
+        );
+    }
+
+    /**
      * Registers vegetation features using the bootstrap context
      *
      * @param context The bootstrap context
@@ -90,10 +109,13 @@ public class ModVegetationFeatures {
         HolderGetter<PlacedFeature> placedFeatureGetter = context.lookup(Registries.PLACED_FEATURE);
 
         Holder<PlacedFeature> cherryBlossomTreeBees02 = placedFeatureGetter.getOrThrow(ModTreePlacements.CHERRY_BLOSSOM_BEES_02);
+        Holder<PlacedFeature> cherryBlossomTreeOnSnow = placedFeatureGetter.getOrThrow(ModTreePlacements.CHERRY_BLOSSOM_ON_SNOW);
         Holder<PlacedFeature> fancyCherryBlossomTree = placedFeatureGetter.getOrThrow(ModTreePlacements.FANCY_CHERRY_BLOSSOM_CHECKED);
+        Holder<PlacedFeature> fancyCherryBlossomTreeOnSnow = placedFeatureGetter.getOrThrow(ModTreePlacements.FANCY_CHERRY_BLOSSOM_ON_SNOW);
         Holder<PlacedFeature> grandCherryBlossomTree = placedFeatureGetter.getOrThrow(ModTreePlacements.GRAND_CHERRY_BLOSSOM_CHECKED);
 
         context.register(TREES_CHERY_BLOSSOM_GROTTO, new ConfiguredFeature<>(Feature.RANDOM_SELECTOR, createCherryBlossomGrottoTreesConfiguration(cherryBlossomTreeBees02, fancyCherryBlossomTree, grandCherryBlossomTree)));
         context.register(CHERY_BLOSSOM_GROTTO_FLOWERS, new ConfiguredFeature<>(Feature.SIMPLE_RANDOM_SELECTOR, createCherryBlossomGrottoFlowersConfiguration()));
+        context.register(TREES_CHERY_BLOSSOM_SLOPES, new ConfiguredFeature<>(Feature.RANDOM_SELECTOR, createCherryBlossomSlopesTreesConfiguration(cherryBlossomTreeOnSnow, fancyCherryBlossomTreeOnSnow)));
     }
 }

--- a/src/main/java/com/deku/cherryblossomgrotto/common/features/ModVegetationFeatures.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/features/ModVegetationFeatures.java
@@ -8,7 +8,9 @@ import net.minecraft.core.HolderSet;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.worldgen.BootstapContext;
 import net.minecraft.data.worldgen.features.FeatureUtils;
+import net.minecraft.data.worldgen.features.VegetationFeatures;
 import net.minecraft.data.worldgen.placement.PlacementUtils;
+import net.minecraft.data.worldgen.placement.TreePlacements;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.Blocks;
@@ -27,6 +29,8 @@ public class ModVegetationFeatures {
     public static ResourceKey<ConfiguredFeature<?, ?>> TREES_CHERY_BLOSSOM_GROTTO = registerVegetationFeatureKey("trees_cherry_blossom_grotto");
     public static ResourceKey<ConfiguredFeature<?, ?>> CHERY_BLOSSOM_GROTTO_FLOWERS = registerVegetationFeatureKey("cherry_blossom_grotto_flowers");
     public static ResourceKey<ConfiguredFeature<?, ?>> TREES_CHERY_BLOSSOM_SLOPES = registerVegetationFeatureKey("trees_cherry_blossom_slopes");
+    public static ResourceKey<ConfiguredFeature<?, ?>> TREES_CHERY_BLOSSOM_SPARSE = registerVegetationFeatureKey("trees_cherry_blossom_sparse");
+    public static ResourceKey<ConfiguredFeature<?, ?>> CHERRY_BLOSSOM_BAMBOO_VEGETATION = registerVegetationFeatureKey("cherry_blossom_bamboo_vegetation");
 
     /**
      * Registers a resource key for the given vegetation feature name
@@ -101,21 +105,62 @@ public class ModVegetationFeatures {
     }
 
     /**
+     * Creates a feature configuration for the sparse cherry blossom trees
+     *
+     * @param cherryBlossomTree Holder for the placeable cherry blossom trees feature
+     * @param fancyCherryBlossomTree Holder for the placeable fancy cherry blossom trees feature
+     * @return Random feature configuration for spreading the trees
+     */
+    private static RandomFeatureConfiguration createCherryBlossomSparseTreesConfiguration(Holder<PlacedFeature> cherryBlossomTree, Holder<PlacedFeature> fancyCherryBlossomTree) {
+        return new RandomFeatureConfiguration(
+                ImmutableList.of(
+                        new WeightedPlacedFeature(fancyCherryBlossomTree, 0.1f)
+                ),
+                cherryBlossomTree
+        );
+    }
+
+    /**
+     * Creates a feature configuration for the sparse cherry blossom trees
+     *
+     * @param cherryBlossomTree Holder for the placeable cherry blossom trees feature
+     * @param fancyCherryBlossomTree Holder for the placeable fancy cherry blossom trees feature
+     * @return Random feature configuration for spreading the trees
+     */
+    private static RandomFeatureConfiguration createCherryBlossomBambooVegetationConfiguration(Holder<ConfiguredFeature<?, ?>> jungleGrass, Holder<PlacedFeature> cherryBlossomTree, Holder<PlacedFeature> fancyCherryBlossomTree, Holder<PlacedFeature> jungleBush) {
+        return new RandomFeatureConfiguration(
+            ImmutableList.of(
+                new WeightedPlacedFeature(fancyCherryBlossomTree, 0.05f),
+                new WeightedPlacedFeature(jungleBush, 0.15F),
+                new WeightedPlacedFeature(cherryBlossomTree, 0.7F)
+            ),
+            PlacementUtils.inlinePlaced(jungleGrass)
+        );
+    }
+
+    /**
      * Registers vegetation features using the bootstrap context
      *
      * @param context The bootstrap context
      */
     public static void bootstrap(BootstapContext<ConfiguredFeature<?, ?>> context) {
+        HolderGetter<ConfiguredFeature<?, ?>> configuredFeatureGetter = context.lookup(Registries.CONFIGURED_FEATURE);
         HolderGetter<PlacedFeature> placedFeatureGetter = context.lookup(Registries.PLACED_FEATURE);
 
+        Holder<ConfiguredFeature<?, ?>> jungleGrass = configuredFeatureGetter.getOrThrow(VegetationFeatures.PATCH_GRASS_JUNGLE);
+
+        Holder<PlacedFeature> cherryBlossomTree = placedFeatureGetter.getOrThrow(ModTreePlacements.CHERRY_BLOSSOM_CHECKED);
         Holder<PlacedFeature> cherryBlossomTreeBees02 = placedFeatureGetter.getOrThrow(ModTreePlacements.CHERRY_BLOSSOM_BEES_02);
         Holder<PlacedFeature> cherryBlossomTreeOnSnow = placedFeatureGetter.getOrThrow(ModTreePlacements.CHERRY_BLOSSOM_ON_SNOW);
         Holder<PlacedFeature> fancyCherryBlossomTree = placedFeatureGetter.getOrThrow(ModTreePlacements.FANCY_CHERRY_BLOSSOM_CHECKED);
         Holder<PlacedFeature> fancyCherryBlossomTreeOnSnow = placedFeatureGetter.getOrThrow(ModTreePlacements.FANCY_CHERRY_BLOSSOM_ON_SNOW);
         Holder<PlacedFeature> grandCherryBlossomTree = placedFeatureGetter.getOrThrow(ModTreePlacements.GRAND_CHERRY_BLOSSOM_CHECKED);
+        Holder<PlacedFeature> jungleBush = placedFeatureGetter.getOrThrow(TreePlacements.JUNGLE_BUSH);
 
         context.register(TREES_CHERY_BLOSSOM_GROTTO, new ConfiguredFeature<>(Feature.RANDOM_SELECTOR, createCherryBlossomGrottoTreesConfiguration(cherryBlossomTreeBees02, fancyCherryBlossomTree, grandCherryBlossomTree)));
         context.register(CHERY_BLOSSOM_GROTTO_FLOWERS, new ConfiguredFeature<>(Feature.SIMPLE_RANDOM_SELECTOR, createCherryBlossomGrottoFlowersConfiguration()));
         context.register(TREES_CHERY_BLOSSOM_SLOPES, new ConfiguredFeature<>(Feature.RANDOM_SELECTOR, createCherryBlossomSlopesTreesConfiguration(cherryBlossomTreeOnSnow, fancyCherryBlossomTreeOnSnow)));
+        context.register(TREES_CHERY_BLOSSOM_SPARSE, new ConfiguredFeature<>(Feature.RANDOM_SELECTOR, createCherryBlossomSparseTreesConfiguration(cherryBlossomTreeBees02, fancyCherryBlossomTree)));
+        context.register(CHERRY_BLOSSOM_BAMBOO_VEGETATION, new ConfiguredFeature<>(Feature.RANDOM_SELECTOR, createCherryBlossomBambooVegetationConfiguration(jungleGrass, cherryBlossomTree, fancyCherryBlossomTree, jungleBush)));
     }
 }

--- a/src/main/java/com/deku/cherryblossomgrotto/common/world/gen/biomes/ModBiomeInitializer.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/world/gen/biomes/ModBiomeInitializer.java
@@ -21,6 +21,8 @@ public class ModBiomeInitializer {
     public static ResourceKey<Biome> CHERRY_BLOSSOM_GROTTO = registerBiomeKey("cherry_blossom_grotto");
 
     public static ResourceKey<Biome> CHERRY_BLOSSOM_SLOPES = registerBiomeKey("cherry_blossom_slopes");
+
+    public static ResourceKey<Biome> CHERRY_BLOSSOM_BAMBOO_JUNGLE = registerBiomeKey("cherry_blossom_bamboo_jungle");
     /**
      * Registers the biome into the vanilla game by the biome registry
      *
@@ -42,6 +44,7 @@ public class ModBiomeInitializer {
 
         context.register(CHERRY_BLOSSOM_GROTTO, OverworldBiomes.theVoid(placementGetter, carverGetter));
         context.register(CHERRY_BLOSSOM_SLOPES, OverworldBiomes.theVoid(placementGetter, carverGetter));
+        context.register(CHERRY_BLOSSOM_BAMBOO_JUNGLE, OverworldBiomes.theVoid(placementGetter, carverGetter));
     }
 
     /**
@@ -51,5 +54,6 @@ public class ModBiomeInitializer {
     public static void registerBiomes() {
         BiomeManager.addBiome(BiomeManager.BiomeType.COOL, new BiomeManager.BiomeEntry(CHERRY_BLOSSOM_GROTTO, 1));
         BiomeManager.addBiome(BiomeManager.BiomeType.COOL, new BiomeManager.BiomeEntry(CHERRY_BLOSSOM_SLOPES, 1));
+        BiomeManager.addBiome(BiomeManager.BiomeType.WARM, new BiomeManager.BiomeEntry(CHERRY_BLOSSOM_BAMBOO_JUNGLE, 1));
     }
 }

--- a/src/main/java/com/deku/cherryblossomgrotto/common/world/gen/biomes/ModBiomeInitializer.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/world/gen/biomes/ModBiomeInitializer.java
@@ -19,6 +19,8 @@ public class ModBiomeInitializer {
     public static final DeferredRegister<Biome> BIOMES = DeferredRegister.create(ForgeRegistries.BIOMES, MOD_ID);
 
     public static ResourceKey<Biome> CHERRY_BLOSSOM_GROTTO = registerBiomeKey("cherry_blossom_grotto");
+
+    public static ResourceKey<Biome> CHERRY_BLOSSOM_SLOPES = registerBiomeKey("cherry_blossom_slopes");
     /**
      * Registers the biome into the vanilla game by the biome registry
      *
@@ -39,6 +41,7 @@ public class ModBiomeInitializer {
         HolderGetter<ConfiguredWorldCarver<?>> carverGetter = context.lookup(Registries.CONFIGURED_CARVER);
 
         context.register(CHERRY_BLOSSOM_GROTTO, OverworldBiomes.theVoid(placementGetter, carverGetter));
+        context.register(CHERRY_BLOSSOM_SLOPES, OverworldBiomes.theVoid(placementGetter, carverGetter));
     }
 
     /**
@@ -47,5 +50,6 @@ public class ModBiomeInitializer {
      */
     public static void registerBiomes() {
         BiomeManager.addBiome(BiomeManager.BiomeType.COOL, new BiomeManager.BiomeEntry(CHERRY_BLOSSOM_GROTTO, 1));
+        BiomeManager.addBiome(BiomeManager.BiomeType.COOL, new BiomeManager.BiomeEntry(CHERRY_BLOSSOM_SLOPES, 1));
     }
 }

--- a/src/main/java/com/deku/cherryblossomgrotto/common/world/gen/biomes/ModBiomeProvider.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/world/gen/biomes/ModBiomeProvider.java
@@ -66,6 +66,7 @@ public class ModBiomeProvider extends Region {
         addModifiedVanillaOverworldBiomes(mapper, builder -> {
             builder.replaceBiome(Biomes.FLOWER_FOREST, ModBiomeInitializer.CHERRY_BLOSSOM_GROTTO);
             builder.replaceBiome(Biomes.GROVE, ModBiomeInitializer.CHERRY_BLOSSOM_SLOPES);
+            builder.replaceBiome(Biomes.SPARSE_JUNGLE, ModBiomeInitializer.CHERRY_BLOSSOM_BAMBOO_JUNGLE);
         });
     }
 }

--- a/src/main/java/com/deku/cherryblossomgrotto/common/world/gen/biomes/ModBiomeProvider.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/world/gen/biomes/ModBiomeProvider.java
@@ -20,7 +20,8 @@ import static com.deku.cherryblossomgrotto.Main.MOD_ID;
 
 public class ModBiomeProvider extends Region {
     public ModBiomeProvider() {
-        super(new ResourceLocation(MOD_ID, "biome_provider"), RegionType.OVERWORLD, 10);
+        // Adding low region weight since we only have one biome. Don't want it to be too common
+        super(new ResourceLocation(MOD_ID, "eastern_region"), RegionType.OVERWORLD, 2);
     }
 
     /**
@@ -63,8 +64,8 @@ public class ModBiomeProvider extends Region {
         });*/
 
         addModifiedVanillaOverworldBiomes(mapper, builder -> {
-            List<Climate.ParameterPoint> flowerForestPoints = RegionUtils.getVanillaParameterPoints(Biomes.FLOWER_FOREST).stream().collect(ImmutableList.toImmutableList());
-            flowerForestPoints.forEach(point -> builder.replaceBiome(point, ModBiomeInitializer.CHERRY_BLOSSOM_GROTTO));
+            builder.replaceBiome(Biomes.FLOWER_FOREST, ModBiomeInitializer.CHERRY_BLOSSOM_GROTTO);
+            builder.replaceBiome(Biomes.GROVE, ModBiomeInitializer.CHERRY_BLOSSOM_SLOPES);
         });
     }
 }

--- a/src/main/java/com/deku/cherryblossomgrotto/common/world/gen/biomes/ModSurfaceRules.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/world/gen/biomes/ModSurfaceRules.java
@@ -1,0 +1,179 @@
+package com.deku.cherryblossomgrotto.common.world.gen.biomes;
+
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.levelgen.Noises;
+import net.minecraft.world.level.levelgen.SurfaceRules;
+
+public class ModSurfaceRules {
+    private static final SurfaceRules.RuleSource DIRT = makeStateRule(Blocks.DIRT);
+    private static final SurfaceRules.RuleSource SNOW_BLOCK = makeStateRule(Blocks.SNOW_BLOCK);
+    private static final SurfaceRules.RuleSource POWDER_SNOW = makeStateRule(Blocks.POWDER_SNOW);
+
+    /**
+     * Makes a state rule based off of a given block
+     *
+     * @param block The block whose default state we want to turn into a surface rule
+     * @return Rule for spreading a given block across the surface
+     */
+    private static SurfaceRules.RuleSource makeStateRule(Block block) {
+        return SurfaceRules.state(block.defaultBlockState());
+    }
+
+    /**
+     * Builds the surface rules that this mod adds to the game.
+     * Currently builds surface rules for:
+     * - Cherry Blossom Slopes - to ensure dirt and snow layering similar to a vanilla grove biome
+     *
+     * @return The surface rules to be added to the game
+     */
+    public static SurfaceRules.RuleSource makeRules() {
+        return SurfaceRules.sequence(
+            SurfaceRules.ifTrue(
+                SurfaceRules.isBiome(ModBiomeInitializer.CHERRY_BLOSSOM_SLOPES),
+                cherryBlossomSlopesSurfaceRules()
+            )
+        );
+    }
+
+    /**
+     * Condition to check if the surface area is above water level
+     *
+     * @return Returns true if the surface area is above water level
+     */
+    private static SurfaceRules.ConditionSource isAboveWaterLevel() {
+        return SurfaceRules.waterBlockCheck(0, 0);
+    }
+
+    /**
+     * Condition to check if the surface area is at or above water level
+     *
+     * @return Returns true if the surface area is at or above water level
+     */
+    private static SurfaceRules.ConditionSource isAtOrAboveWaterLevel() {
+        return SurfaceRules.waterBlockCheck(-1, 0);
+    }
+
+    /**
+     * Condition to check if the surface area is slightly below water level
+     * Slightly below water level being up to 6 blocks below.
+     *
+     * @return Returns true if the surface area is around 6 blocks below water level
+     */
+    private static SurfaceRules.ConditionSource isSlightlyBelowWaterLevel() {
+        return SurfaceRules.waterStartCheck(-6, -1);
+    }
+
+    /**
+     * Checks if the surface is covered in powdered snow.
+     * Uses some level to noise to randomize the change and only makes the change above water level
+     *
+     * @return A surface rule that will randomly mark some powdered snow for change
+     */
+    private static SurfaceRules.RuleSource surfacePowderSnowCheck() {
+        return SurfaceRules.ifTrue(
+            SurfaceRules.noiseCondition(Noises.POWDER_SNOW, 0.45D, 0.58D),
+            SurfaceRules.ifTrue(
+                isAboveWaterLevel(),
+                POWDER_SNOW
+            )
+        );
+    }
+
+    /**
+     * Checks if the surface is covered in powdered snow.
+     * Uses some level of noise to randomize the change and only makes the change above water level
+     *
+     * @return A surface rule that will randomly mark some powdered snow for change
+     */
+    private static SurfaceRules.RuleSource surfaceDeepPowderSnowCheck() {
+        return SurfaceRules.ifTrue(
+            SurfaceRules.noiseCondition(Noises.POWDER_SNOW, 0.35D, 0.6D),
+            SurfaceRules.ifTrue(
+                isAboveWaterLevel(),
+                POWDER_SNOW
+            )
+        );
+    }
+
+    /**
+     * Using the powdered snow conditional, convert marked snow blocks to powdered snow and layer the rest as normal snow blocks
+     *
+     * @return The rule for layering snow but converting some to powdered snow
+     */
+    private static SurfaceRules.RuleSource surfaceSnowWithPowderedSnow() {
+        return SurfaceRules.sequence(
+            surfacePowderSnowCheck(),
+            SurfaceRules.ifTrue(
+                isAboveWaterLevel(),
+                SNOW_BLOCK
+            )
+        );
+    }
+
+    /**
+     * Using the powdered snow condition, convert marked blocks to powdered snow and layer the rest as dirt
+     *
+     * @return The rule for layering dirt but converting some to powdered snow
+     */
+    private static SurfaceRules.RuleSource surfaceDirtWithPowderedSnow() {
+        return SurfaceRules.sequence(
+            surfaceDeepPowderSnowCheck(),
+            DIRT
+        );
+    }
+
+    /**
+     * Builds the surface rules for the cherry blossom slopes biome
+     * These rules do the following:
+     * - On the surface, one layer of snow peppered with powdered snow
+     * - Below the surface (just a block or two deep) layer dirt peppered with powdered snow
+     *
+     * @return The surface rules for the cherry blossom slopes biome
+     */
+    private static SurfaceRules.RuleSource cherryBlossomSlopesSurfaceRules() {
+        // Surface rules for spawning powdered snow, replacing some of the generated snow
+        SurfaceRules.RuleSource groundRules = SurfaceRules.ifTrue(
+            SurfaceRules.ON_FLOOR,
+            SurfaceRules.ifTrue(
+                isAtOrAboveWaterLevel(),
+                surfaceSnowWithPowderedSnow()
+            )
+        );
+
+        // Surface rules for spawning dirt underneath top layers of the surface, peppered with powdered snow
+        SurfaceRules.RuleSource buriedGroundRules = SurfaceRules.ifTrue(
+            isSlightlyBelowWaterLevel(),
+            SurfaceRules.ifTrue(
+                SurfaceRules.UNDER_FLOOR,
+                SurfaceRules.sequence(
+                    surfaceDirtWithPowderedSnow(),
+                    DIRT
+                )
+            )
+        );
+
+        // Surface rules for spawning snow where there would otherwise be dirt in underground caves
+        // NOTE: To use this it needs to happen OUTSIDE of the abovePreliminarySurface() conditional
+        SurfaceRules.RuleSource undergroundRules = SurfaceRules.ifTrue(
+            isSlightlyBelowWaterLevel(),
+            SurfaceRules.ifTrue(
+                SurfaceRules.UNDER_FLOOR,
+                SurfaceRules.sequence(
+                    surfaceDirtWithPowderedSnow(),
+                    DIRT
+                )
+            )
+        );
+
+        return SurfaceRules.ifTrue(
+            SurfaceRules.abovePreliminarySurface(),
+            SurfaceRules.sequence(
+                groundRules,
+                buriedGroundRules
+            )
+        );
+    }
+}
+
+

--- a/src/main/java/com/deku/cherryblossomgrotto/common/world/gen/placements/ModTreePlacements.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/world/gen/placements/ModTreePlacements.java
@@ -2,14 +2,20 @@ package com.deku.cherryblossomgrotto.common.world.gen.placements;
 
 import com.deku.cherryblossomgrotto.common.blocks.ModBlocks;
 import com.deku.cherryblossomgrotto.common.features.ModTreeFeatures;
+import net.minecraft.core.Direction;
 import net.minecraft.core.HolderGetter;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.worldgen.BootstapContext;
 import net.minecraft.data.worldgen.placement.PlacementUtils;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.levelgen.blockpredicates.BlockPredicate;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
+import net.minecraft.world.level.levelgen.placement.BlockPredicateFilter;
+import net.minecraft.world.level.levelgen.placement.EnvironmentScanPlacement;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+import net.minecraft.world.level.levelgen.placement.PlacementModifier;
 
 import java.util.List;
 
@@ -20,8 +26,11 @@ public class ModTreePlacements {
     public static ResourceKey<PlacedFeature> CHERRY_BLOSSOM_BEES_002 = registerTreePlacementKey("cherry_blossom_bees_002");
     public static ResourceKey<PlacedFeature> CHERRY_BLOSSOM_BEES_02 = registerTreePlacementKey("cherry_blossom_bees_02");
     public static ResourceKey<PlacedFeature> CHERRY_BLOSSOM_BEES_05 = registerTreePlacementKey("cherry_blossom_bees_05");
+    public static ResourceKey<PlacedFeature> CHERRY_BLOSSOM_ON_SNOW = registerTreePlacementKey("cherry_blossom_on_snow");
     public static ResourceKey<PlacedFeature> FANCY_CHERRY_BLOSSOM_CHECKED = registerTreePlacementKey("fancy_cherry_blossom_checked");
     public static ResourceKey<PlacedFeature> FANCY_CHERRY_BLOSSOM_BEES_05 = registerTreePlacementKey("fancy_cherry_blossom_bees_05");
+    public static ResourceKey<PlacedFeature> FANCY_CHERRY_BLOSSOM_ON_SNOW = registerTreePlacementKey("fancy_cherry_blossom_on_snow");
+
     public static ResourceKey<PlacedFeature> GRAND_CHERRY_BLOSSOM_CHECKED = registerTreePlacementKey("grand_cherry_blossom_checked");
 
     /**
@@ -46,8 +55,21 @@ public class ModTreePlacements {
         context.register(CHERRY_BLOSSOM_BEES_002, new PlacedFeature(featureGetter.getOrThrow(ModTreeFeatures.CHERRY_BLOSSOM_BEES_002), List.of(PlacementUtils.filteredByBlockSurvival(ModBlocks.CHERRY_SAPLING))));
         context.register(CHERRY_BLOSSOM_BEES_02, new PlacedFeature(featureGetter.getOrThrow(ModTreeFeatures.CHERRY_BLOSSOM_BEES_02), List.of(PlacementUtils.filteredByBlockSurvival(ModBlocks.CHERRY_SAPLING))));
         context.register(CHERRY_BLOSSOM_BEES_05, new PlacedFeature(featureGetter.getOrThrow(ModTreeFeatures.CHERRY_BLOSSOM_BEES_05), List.of(PlacementUtils.filteredByBlockSurvival(ModBlocks.CHERRY_SAPLING))));
+        context.register(CHERRY_BLOSSOM_ON_SNOW, new PlacedFeature(featureGetter.getOrThrow(ModTreeFeatures.CHERRY_BLOSSOM), surviveOnSnowPredicate()));
         context.register(FANCY_CHERRY_BLOSSOM_CHECKED, new PlacedFeature(featureGetter.getOrThrow(ModTreeFeatures.FANCY_CHERRY_BLOSSOM), List.of(PlacementUtils.filteredByBlockSurvival(ModBlocks.CHERRY_SAPLING))));
         context.register(FANCY_CHERRY_BLOSSOM_BEES_05, new PlacedFeature(featureGetter.getOrThrow(ModTreeFeatures.FANCY_CHERRY_BLOSSOM_BEES_05), List.of(PlacementUtils.filteredByBlockSurvival(ModBlocks.CHERRY_SAPLING))));
+        context.register(FANCY_CHERRY_BLOSSOM_ON_SNOW, new PlacedFeature(featureGetter.getOrThrow(ModTreeFeatures.FANCY_CHERRY_BLOSSOM), surviveOnSnowPredicate()));
         context.register(GRAND_CHERRY_BLOSSOM_CHECKED, new PlacedFeature(featureGetter.getOrThrow(ModTreeFeatures.GRAND_CHERRY_BLOSSOM), List.of(PlacementUtils.filteredByBlockSurvival(ModBlocks.CHERRY_SAPLING))));
+    }
+
+    /**
+     * Builds a list of placement modifiers that check if the tree can spawn on snow.
+     * Only passes if the block the tree is growing from is a type of snow and that there isn't 8 or more blocks of powdered snow in the way
+
+     * @return The list of placement modifiers that will determine if a tree can be spawned
+     */
+    private static List<PlacementModifier> surviveOnSnowPredicate() {
+        BlockPredicate snowPredicate = BlockPredicate.matchesBlocks(Direction.DOWN.getNormal(), Blocks.SNOW_BLOCK, Blocks.POWDER_SNOW);
+        return List.of(EnvironmentScanPlacement.scanningFor(Direction.UP, BlockPredicate.not(BlockPredicate.matchesBlocks(Blocks.POWDER_SNOW)), 8), BlockPredicateFilter.forPredicate(snowPredicate));
     }
 }

--- a/src/main/java/com/deku/cherryblossomgrotto/common/world/gen/placements/ModVegetationPlacements.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/world/gen/placements/ModVegetationPlacements.java
@@ -21,6 +21,8 @@ public class ModVegetationPlacements {
     public static ResourceKey<PlacedFeature> TREES_CHERRY_BLOSSOM_GROTTO = registerVegetationPlacementKey("trees_cherry_blossom_grotto");
     public static ResourceKey<PlacedFeature> CHERRY_BLOSSOM_GROTTO_FLOWERS = registerVegetationPlacementKey("cherry_blossom_grotto_flowers");
     public static ResourceKey<PlacedFeature> TREES_CHERRY_BLOSSOM_SLOPES = registerVegetationPlacementKey("trees_cherry_blossom_slopes");
+    public static ResourceKey<PlacedFeature> TREES_CHERRY_BLOSSOM_SPARSE = registerVegetationPlacementKey("trees_cherry_blossom_sparse");
+    public static ResourceKey<PlacedFeature> CHERRY_BLOSSOM_BAMBOO_VEGETATION = registerVegetationPlacementKey("cherry_blossom_bamboo_vegetation");
 
     /**
      * Registers the vegetation placements into the vanilla game by the placed feature registry
@@ -47,5 +49,7 @@ public class ModVegetationPlacements {
             CountPlacement.of(ClampedInt.of(UniformInt.of(-1, 3), 0, 3)),
             BiomeFilter.biome())));
         context.register(TREES_CHERRY_BLOSSOM_SLOPES, new PlacedFeature(featureGetter.getOrThrow(ModVegetationFeatures.TREES_CHERY_BLOSSOM_SLOPES), VegetationPlacements.treePlacement(PlacementUtils.countExtra(3, 0.1F, 1))));
+        context.register(TREES_CHERRY_BLOSSOM_SPARSE, new PlacedFeature(featureGetter.getOrThrow(ModVegetationFeatures.TREES_CHERY_BLOSSOM_GROTTO), VegetationPlacements.treePlacement(PlacementUtils.countExtra(0, 0.1F, 1))));
+        context.register(CHERRY_BLOSSOM_BAMBOO_VEGETATION, new PlacedFeature(featureGetter.getOrThrow(ModVegetationFeatures.CHERRY_BLOSSOM_BAMBOO_VEGETATION), VegetationPlacements.treePlacement(PlacementUtils.countExtra(30, 0.1F, 1))));
     }
 }

--- a/src/main/java/com/deku/cherryblossomgrotto/common/world/gen/placements/ModVegetationPlacements.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/world/gen/placements/ModVegetationPlacements.java
@@ -20,6 +20,7 @@ import static com.deku.cherryblossomgrotto.Main.MOD_ID;
 public class ModVegetationPlacements {
     public static ResourceKey<PlacedFeature> TREES_CHERRY_BLOSSOM_GROTTO = registerVegetationPlacementKey("trees_cherry_blossom_grotto");
     public static ResourceKey<PlacedFeature> CHERRY_BLOSSOM_GROTTO_FLOWERS = registerVegetationPlacementKey("cherry_blossom_grotto_flowers");
+    public static ResourceKey<PlacedFeature> TREES_CHERRY_BLOSSOM_SLOPES = registerVegetationPlacementKey("trees_cherry_blossom_slopes");
 
     /**
      * Registers the vegetation placements into the vanilla game by the placed feature registry
@@ -45,5 +46,6 @@ public class ModVegetationPlacements {
             PlacementUtils.HEIGHTMAP,
             CountPlacement.of(ClampedInt.of(UniformInt.of(-1, 3), 0, 3)),
             BiomeFilter.biome())));
+        context.register(TREES_CHERRY_BLOSSOM_SLOPES, new PlacedFeature(featureGetter.getOrThrow(ModVegetationFeatures.TREES_CHERY_BLOSSOM_SLOPES), VegetationPlacements.treePlacement(PlacementUtils.countExtra(3, 0.1F, 1))));
     }
 }

--- a/src/main/resources/assets/cherryblossomgrotto/lang/en_us.json
+++ b/src/main/resources/assets/cherryblossomgrotto/lang/en_us.json
@@ -65,6 +65,7 @@
   "entity.cherryblossomgrotto.cherry_blossom_chest_boat": "Cherry Blossom Chest Boat",
   "biome.cherryblossomgrotto.cherry_blossom_grotto": "Cherry Blossom Grotto",
   "biome.cherryblossomgrotto.cherry_blossom_slopes": "Cherry Blossom Slopes",
+  "biome.cherryblossomgrotto.cherry_blossom_bamboo_jungle": "Cherry Blossom Bamboo Jungle",
   "enchantment.cherryblossomgrotto.double_jump": "Double Jump",
   "enchantment.cherryblossomgrotto.double_jump.desc": "Enables double jumping",
   "subtitles.entity.player.double_jump": "Player double jumps",

--- a/src/main/resources/assets/cherryblossomgrotto/lang/en_us.json
+++ b/src/main/resources/assets/cherryblossomgrotto/lang/en_us.json
@@ -64,7 +64,7 @@
   "entity.cherryblossomgrotto.cherry_blossom_boat": "Cherry Blossom Boat",
   "entity.cherryblossomgrotto.cherry_blossom_chest_boat": "Cherry Blossom Chest Boat",
   "biome.cherryblossomgrotto.cherry_blossom_grotto": "Cherry Blossom Grotto",
-  "biome.cherryblossomgrotto.stone_forest": "Stone Forest",
+  "biome.cherryblossomgrotto.cherry_blossom_slopes": "Cherry Blossom Slopes",
   "enchantment.cherryblossomgrotto.double_jump": "Double Jump",
   "enchantment.cherryblossomgrotto.double_jump.desc": "Enables double jumping",
   "subtitles.entity.player.double_jump": "Player double jumps",

--- a/src/main/resources/data/cherryblossomgrotto/tags/worldgen/biome/has_structure/giant_buddha.json
+++ b/src/main/resources/data/cherryblossomgrotto/tags/worldgen/biome/has_structure/giant_buddha.json
@@ -7,6 +7,7 @@
     "minecraft:snowy_slopes",
     "minecraft:snowy_taiga",
     "minecraft:old_growth_spruce_taiga",
-    "cherryblossomgrotto:cherry_blossom_grotto"
+    "cherryblossomgrotto:cherry_blossom_grotto",
+    "cherryblossomgrotto:cherry_blossom_slopes"
   ]
 }

--- a/src/main/resources/data/cherryblossomgrotto/tags/worldgen/biome/has_structure/giant_buddha.json
+++ b/src/main/resources/data/cherryblossomgrotto/tags/worldgen/biome/has_structure/giant_buddha.json
@@ -8,6 +8,7 @@
     "minecraft:snowy_taiga",
     "minecraft:old_growth_spruce_taiga",
     "cherryblossomgrotto:cherry_blossom_grotto",
-    "cherryblossomgrotto:cherry_blossom_slopes"
+    "cherryblossomgrotto:cherry_blossom_slopes",
+    "cherryblossomgrotto:cherry_blossom_bamboo_jungle"
   ]
 }

--- a/src/main/resources/data/cherryblossomgrotto/tags/worldgen/biome/has_structure/ruined_torii_portal.json
+++ b/src/main/resources/data/cherryblossomgrotto/tags/worldgen/biome/has_structure/ruined_torii_portal.json
@@ -1,6 +1,7 @@
 {
   "replace": false,
   "values": [
-    "cherryblossomgrotto:cherry_blossom_grotto"
+    "cherryblossomgrotto:cherry_blossom_grotto",
+    "cherryblossomgrotto:cherry_blossom_slopes"
   ]
 }

--- a/src/main/resources/data/cherryblossomgrotto/tags/worldgen/biome/has_structure/ruined_torii_portal.json
+++ b/src/main/resources/data/cherryblossomgrotto/tags/worldgen/biome/has_structure/ruined_torii_portal.json
@@ -2,6 +2,7 @@
   "replace": false,
   "values": [
     "cherryblossomgrotto:cherry_blossom_grotto",
-    "cherryblossomgrotto:cherry_blossom_slopes"
+    "cherryblossomgrotto:cherry_blossom_slopes",
+    "cherryblossomgrotto:cherry_blossom_bamboo_jungle"
   ]
 }

--- a/src/main/resources/data/cherryblossomgrotto/tags/worldgen/biome/has_structure/torii_gate.json
+++ b/src/main/resources/data/cherryblossomgrotto/tags/worldgen/biome/has_structure/torii_gate.json
@@ -4,6 +4,7 @@
     "minecraft:bamboo_jungle",
     "minecraft:snowy_slopes",
     "minecraft:beach",
-    "cherryblossomgrotto:cherry_blossom_grotto"
+    "cherryblossomgrotto:cherry_blossom_grotto",
+    "cherryblossomgrotto:cherry_blossom_slopes"
   ]
 }

--- a/src/main/resources/data/cherryblossomgrotto/tags/worldgen/biome/has_structure/torii_gate.json
+++ b/src/main/resources/data/cherryblossomgrotto/tags/worldgen/biome/has_structure/torii_gate.json
@@ -5,6 +5,7 @@
     "minecraft:snowy_slopes",
     "minecraft:beach",
     "cherryblossomgrotto:cherry_blossom_grotto",
-    "cherryblossomgrotto:cherry_blossom_slopes"
+    "cherryblossomgrotto:cherry_blossom_slopes",
+    "cherryblossomgrotto:cherry_blossom_bamboo_jungle"
   ]
 }

--- a/src/main/resources/data/cherryblossomgrotto/tags/worldgen/biome/has_structure/village_cherry_blossom_grotto.json
+++ b/src/main/resources/data/cherryblossomgrotto/tags/worldgen/biome/has_structure/village_cherry_blossom_grotto.json
@@ -1,6 +1,7 @@
 {
   "replace": false,
   "values": [
-    "cherryblossomgrotto:cherry_blossom_grotto"
+    "cherryblossomgrotto:cherry_blossom_grotto",
+    "cherryblossomgrotto:cherry_blossom_slopes"
   ]
 }

--- a/src/main/resources/data/cherryblossomgrotto/tags/worldgen/biome/has_structure/village_cherry_blossom_grotto.json
+++ b/src/main/resources/data/cherryblossomgrotto/tags/worldgen/biome/has_structure/village_cherry_blossom_grotto.json
@@ -2,6 +2,7 @@
   "replace": false,
   "values": [
     "cherryblossomgrotto:cherry_blossom_grotto",
-    "cherryblossomgrotto:cherry_blossom_slopes"
+    "cherryblossomgrotto:cherry_blossom_slopes",
+    "cherryblossomgrotto:cherry_blossom_bamboo_jungle"
   ]
 }

--- a/src/main/resources/data/cherryblossomgrotto/tags/worldgen/biome/is_cherry_blossom_grotto.json
+++ b/src/main/resources/data/cherryblossomgrotto/tags/worldgen/biome/is_cherry_blossom_grotto.json
@@ -1,6 +1,7 @@
 {
   "replace": false,
   "values": [
-    "cherryblossomgrotto:cherry_blossom_grotto"
+    "cherryblossomgrotto:cherry_blossom_grotto",
+    "cherryblossomgrotto:cherry_blossom_slopes"
   ]
 }

--- a/src/main/resources/data/cherryblossomgrotto/tags/worldgen/biome/is_cherry_blossom_grotto.json
+++ b/src/main/resources/data/cherryblossomgrotto/tags/worldgen/biome/is_cherry_blossom_grotto.json
@@ -2,6 +2,7 @@
   "replace": false,
   "values": [
     "cherryblossomgrotto:cherry_blossom_grotto",
-    "cherryblossomgrotto:cherry_blossom_slopes"
+    "cherryblossomgrotto:cherry_blossom_slopes",
+    "cherryblossomgrotto:cherry_blossom_bamboo_jungle"
   ]
 }

--- a/src/main/resources/data/cherryblossomgrotto/worldgen/biome/cherry_blossom_bamboo_jungle.json
+++ b/src/main/resources/data/cherryblossomgrotto/worldgen/biome/cherry_blossom_bamboo_jungle.json
@@ -1,11 +1,11 @@
 {
-  "surface_builder": "minecraft:dirt",
+  "surface_builder": "minecraft:grass",
   "depth": 0.125,
   "scale": 0.05,
-  "temperature": -0.3,
+  "temperature": 0.8,
   "temperature_modifier": "none",
   "downfall": 0.9,
-  "precipitation": "snow",
+  "precipitation": "rain",
   "player_spawn_friendly": true,
   "creature_spawn_friendly": true,
   "creature_spawn_probability": 0.5,
@@ -27,7 +27,7 @@
       "max_delay": 24000,
       "min_delay": 12000,
       "replace_current_music": false,
-      "sound": "minecraft:music.overworld.snowy_slopes"
+      "sound": "minecraft:music.overworld.jungle_and_forest"
     }
   },
   "spawners": {
@@ -79,6 +79,12 @@
         "weight": 5,
         "minCount": 1,
         "maxCount": 1
+      },
+      {
+        "type": "minecraft:ocelot",
+        "weight": 2,
+        "minCount": 1,
+        "maxCount": 1
       }
     ],
     "creature": [
@@ -91,8 +97,8 @@
       {
         "type": "minecraft:sheep",
         "weight": 12,
-        "maxCount": 4,
-        "minCount": 4
+        "minCount": 4,
+        "maxCount": 4
       },
       {
         "type": "minecraft:cow",
@@ -101,16 +107,16 @@
         "maxCount": 4
       },
       {
-        "type": "minecraft:horse",
-        "weight": 5,
-        "minCount": 2,
-        "maxCount": 6
+        "type": "minecraft:parrot",
+        "weight": 40,
+        "minCount": 1,
+        "maxCount": 2
       },
       {
-        "type": "minecraft:wolf",
-        "weight": 2,
-        "minCount": 2,
-        "maxCount": 4
+        "type": "minecraft:panda",
+        "weight": 80,
+        "minCount": 1,
+        "maxCount": 2
       },
       {
         "type": "minecraft:rabbit",
@@ -133,8 +139,8 @@
       {
         "type": "minecraft:glow_squid",
         "weight": 10,
-        "maxCount": 6,
-        "minCount": 4
+        "minCount": 4,
+        "maxCount": 6
       }
     ],
     "water_ambient": [
@@ -159,8 +165,7 @@
     [
     ],
     [
-      "minecraft:lake_lava_underground",
-      "minecraft:lake_lava_surface"
+      "minecraft:lake_lava_underground"
     ],
     [
       "minecraft:amethyst_geode",
@@ -211,14 +216,20 @@
     ],
     [
       "minecraft:glow_lichen",
-      "minecraft:patch_tall_grass_2",
-      "minecraft:patch_grass_forest",
+      "minecraft:bamboo",
+      "cherryblossomgrotto:cherry_blossom_bamboo_vegetation",
+      "minecraft:patch_grass_jungle",
+      "minecraft:flower_warm",
       "minecraft:brown_mushroom_normal",
-      "minecraft:patch_berry_common",
-      "cherryblossomgrotto:trees_cherry_blossom_slopes"
+      "minecraft:red_mushroom_normal",
+      "minecraft:patch_sugar_cane",
+      "minecraft:patch_pumpkin",
+      "minecraft:vines",
+      "minecraft:patch_melon",
+      "minecraft:patch_waterlily",
+      "cherryblossomgrotto:cherry_blossom_grotto_flowers"
     ],
     [
-      "minecraft:freeze_top_layer",
       "cherryblossomgrotto:cherry_blossom_petals_top_layer"
     ]
   ]

--- a/src/main/resources/data/cherryblossomgrotto/worldgen/biome/cherry_blossom_grotto.json
+++ b/src/main/resources/data/cherryblossomgrotto/worldgen/biome/cherry_blossom_grotto.json
@@ -124,8 +124,20 @@
     "water_creature": [
     ],
     "underground_water_creature": [
+      {
+        "type": "minecraft:glow_squid",
+        "weight": 10,
+        "maxCount": 6,
+        "minCount": 4
+      }
     ],
     "water_ambient": [
+      {
+        "type": "cherryblossomgrotto:koi",
+        "weight": 25,
+        "maxCount": 8,
+        "minCount": 8
+      }
     ],
     "misc": [
     ],
@@ -137,6 +149,7 @@
   "carvers": {
     "air": [
       "minecraft:cave",
+      "minecraft:cave_extra_underground",
       "minecraft:canyon"
     ],
     "liquid": [

--- a/src/main/resources/data/cherryblossomgrotto/worldgen/biome/cherry_blossom_slopes.json
+++ b/src/main/resources/data/cherryblossomgrotto/worldgen/biome/cherry_blossom_slopes.json
@@ -1,11 +1,11 @@
 {
-  "surface_builder": "minecraft:grass",
+  "surface_builder": "minecraft:dirt",
   "depth": 0.125,
   "scale": 0.05,
-  "temperature": 0.8,
+  "temperature": -0.3,
   "temperature_modifier": "none",
-  "downfall": 0.8,
-  "precipitation": "rain",
+  "downfall": 0.9,
+  "precipitation": "snow",
   "player_spawn_friendly": true,
   "creature_spawn_friendly": true,
   "creature_spawn_probability": 0.5,
@@ -27,7 +27,7 @@
       "max_delay": 24000,
       "min_delay": 12000,
       "replace_current_music": false,
-      "sound": "minecraft:music.overworld.jungle_and_forest"
+      "sound": "minecraft:music.overworld.snowy_slopes"
     }
   },
   "spawners": {
@@ -137,6 +137,7 @@
   "carvers": {
     "air": [
       "minecraft:cave",
+      "minecraft:cave_extra_underground",
       "minecraft:canyon"
     ],
     "liquid": [
@@ -198,13 +199,11 @@
       "minecraft:patch_tall_grass_2",
       "minecraft:patch_grass_forest",
       "minecraft:brown_mushroom_normal",
-      "minecraft:patch_sugar_cane",
-      "minecraft:patch_berry_rare",
-      "minecraft:patch_waterlily",
-      "cherryblossomgrotto:trees_cherry_blossom_grotto",
-      "cherryblossomgrotto:cherry_blossom_grotto_flowers"
+      "minecraft:patch_berry_common",
+      "cherryblossomgrotto:trees_cherry_blossom_slopes"
     ],
     [
+      "minecraft:freeze_top_layer",
       "cherryblossomgrotto:cherry_blossom_petals_top_layer"
     ]
   ]

--- a/src/main/resources/data/cherryblossomgrotto/worldgen/configured_feature/cherry_blossom_bamboo_vegetation.json
+++ b/src/main/resources/data/cherryblossomgrotto/worldgen/configured_feature/cherry_blossom_bamboo_vegetation.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:random_selector",
+  "config": {
+    "default": {
+      "feature": "minecraft:patch_grass_jungle",
+      "placement": []
+    },
+    "features": [
+      {
+        "chance": 0.05,
+        "feature": "cherryblossomgrotto:fancy_cherry_blossom_checked"
+      },
+      {
+        "chance": 0.15,
+        "feature": "minecraft:jungle_bush"
+      },
+      {
+        "chance": 0.7,
+        "feature": "cherryblossomgrotto:cherry_blossom_checked"
+      }
+    ]
+  }
+}

--- a/src/main/resources/data/cherryblossomgrotto/worldgen/configured_feature/trees_cherry_blossom_slopes.json
+++ b/src/main/resources/data/cherryblossomgrotto/worldgen/configured_feature/trees_cherry_blossom_slopes.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:random_selector",
+  "config": {
+    "default": "cherryblossomgrotto:cherry_blossom_on_snow",
+    "features": [
+      {
+        "chance": 0.1,
+        "feature":"cherryblossomgrotto:fancy_cherry_blossom_on_snow"
+      }
+    ]
+  }
+}

--- a/src/main/resources/data/cherryblossomgrotto/worldgen/configured_feature/trees_cherry_blossom_sparse.json
+++ b/src/main/resources/data/cherryblossomgrotto/worldgen/configured_feature/trees_cherry_blossom_sparse.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:random_selector",
+  "config": {
+    "default": "cherryblossomgrotto:cherry_blossom_bees_002",
+    "features": [
+      {
+        "chance": 0.1,
+        "feature":"cherryblossomgrotto:fancy_cherry_blossom_checked"
+      }
+    ]
+  }
+}

--- a/src/main/resources/data/cherryblossomgrotto/worldgen/placed_feature/cherry_blossom_bamboo_vegetation.json
+++ b/src/main/resources/data/cherryblossomgrotto/worldgen/placed_feature/cherry_blossom_bamboo_vegetation.json
@@ -1,0 +1,35 @@
+{
+  "feature": "cherryblossomgrotto:cherry_blossom_bamboo_vegetation",
+  "placement": [
+    {
+      "type": "minecraft:count",
+      "count": {
+        "type": "minecraft:weighted_list",
+        "distribution": [
+          {
+            "data": 30,
+            "weight": 9
+          },
+          {
+            "data": 31,
+            "weight": 1
+          }
+        ]
+      }
+    },
+    {
+      "type": "minecraft:in_square"
+    },
+    {
+      "type": "minecraft:surface_water_depth_filter",
+      "max_water_depth": 0
+    },
+    {
+      "type": "minecraft:heightmap",
+      "heightmap": "OCEAN_FLOOR"
+    },
+    {
+      "type": "minecraft:biome"
+    }
+  ]
+}

--- a/src/main/resources/data/cherryblossomgrotto/worldgen/placed_feature/cherry_blossom_on_snow.json
+++ b/src/main/resources/data/cherryblossomgrotto/worldgen/placed_feature/cherry_blossom_on_snow.json
@@ -1,0 +1,28 @@
+{
+  "feature": "cherryblossomgrotto:cherry_blossom",
+  "placement": [
+    {
+      "type": "minecraft:environment_scan",
+      "direction_of_search": "up",
+      "max_steps": 8,
+      "target_condition": {
+        "type": "minecraft:not",
+        "predicate": {
+          "type": "minecraft:matching_blocks",
+          "blocks": "minecraft:powder_snow"
+        }
+      }
+    },
+    {
+      "type": "minecraft:block_predicate_filter",
+      "predicate": {
+        "type": "minecraft:matching_blocks",
+        "blocks": [
+          "minecraft:snow_block",
+          "minecraft:powder_snow"
+        ],
+        "offset": [0, -1, 0]
+      }
+    }
+  ]
+}

--- a/src/main/resources/data/cherryblossomgrotto/worldgen/placed_feature/fancy_cherry_blossom_on_snow.json
+++ b/src/main/resources/data/cherryblossomgrotto/worldgen/placed_feature/fancy_cherry_blossom_on_snow.json
@@ -1,0 +1,28 @@
+{
+  "feature": "cherryblossomgrotto:fancy_cherry_blossom",
+  "placement": [
+    {
+      "type": "minecraft:environment_scan",
+      "direction_of_search": "up",
+      "max_steps": 8,
+      "target_condition": {
+        "type": "minecraft:not",
+        "predicate": {
+          "type": "minecraft:matching_blocks",
+          "blocks": "minecraft:powder_snow"
+        }
+      }
+    },
+    {
+      "type": "minecraft:block_predicate_filter",
+      "predicate": {
+        "type": "minecraft:matching_blocks",
+        "blocks": [
+          "minecraft:snow_block",
+          "minecraft:powder_snow"
+        ],
+        "offset": [0, -1, 0]
+      }
+    }
+  ]
+}

--- a/src/main/resources/data/cherryblossomgrotto/worldgen/placed_feature/trees_cherry_blossom_slopes.json
+++ b/src/main/resources/data/cherryblossomgrotto/worldgen/placed_feature/trees_cherry_blossom_slopes.json
@@ -1,0 +1,35 @@
+{
+  "feature": "cherryblossomgrotto:trees_cherry_blossom_slopes",
+  "placement": [
+    {
+      "type": "minecraft:count",
+      "count": {
+        "type": "minecraft:weighted_list",
+        "distribution": [
+          {
+            "data": 3,
+            "weight": 9
+          },
+          {
+            "data": 4,
+            "weight": 1
+          }
+        ]
+      }
+    },
+    {
+      "type": "minecraft:in_square"
+    },
+    {
+      "type": "minecraft:surface_water_depth_filter",
+      "max_water_depth": 0
+    },
+    {
+      "type": "minecraft:heightmap",
+      "heightmap": "OCEAN_FLOOR"
+    },
+    {
+      "type": "minecraft:biome"
+    }
+  ]
+}

--- a/src/main/resources/data/cherryblossomgrotto/worldgen/placed_feature/trees_cherry_blossom_sparse.json
+++ b/src/main/resources/data/cherryblossomgrotto/worldgen/placed_feature/trees_cherry_blossom_sparse.json
@@ -1,0 +1,35 @@
+{
+  "feature": "cherryblossomgrotto:trees_cherry_blossom_slopes",
+  "placement": [
+    {
+      "type": "minecraft:count",
+      "count": {
+        "type": "minecraft:weighted_list",
+        "distribution": [
+          {
+            "data": 1,
+            "weight": 9
+          },
+          {
+            "data": 1,
+            "weight": 1
+          }
+        ]
+      }
+    },
+    {
+      "type": "minecraft:in_square"
+    },
+    {
+      "type": "minecraft:surface_water_depth_filter",
+      "max_water_depth": 0
+    },
+    {
+      "type": "minecraft:heightmap",
+      "heightmap": "OCEAN_FLOOR"
+    },
+    {
+      "type": "minecraft:biome"
+    }
+  ]
+}

--- a/src/main/resources/data/forge/tags/worldgen/biome/is_cold/overworld.json
+++ b/src/main/resources/data/forge/tags/worldgen/biome/is_cold/overworld.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "cherryblossomgrotto:cherry_blossom_slopes"
+  ]
+}

--- a/src/main/resources/data/forge/tags/worldgen/biome/is_dense.json
+++ b/src/main/resources/data/forge/tags/worldgen/biome/is_dense.json
@@ -1,6 +1,7 @@
 {
   "replace": false,
   "values": [
-    "cherryblossomgrotto:cherry_blossom_grotto"
+    "cherryblossomgrotto:cherry_blossom_grotto",
+    "cherryblossomgrotto:cherry_blossom_slopes"
   ]
 }

--- a/src/main/resources/data/forge/tags/worldgen/biome/is_dense.json
+++ b/src/main/resources/data/forge/tags/worldgen/biome/is_dense.json
@@ -2,6 +2,7 @@
   "replace": false,
   "values": [
     "cherryblossomgrotto:cherry_blossom_grotto",
-    "cherryblossomgrotto:cherry_blossom_slopes"
+    "cherryblossomgrotto:cherry_blossom_slopes",
+    "cherryblossomgrotto:cherry_blossom_bamboo_jungle"
   ]
 }

--- a/src/main/resources/data/forge/tags/worldgen/biome/is_dense/overworld.json
+++ b/src/main/resources/data/forge/tags/worldgen/biome/is_dense/overworld.json
@@ -1,6 +1,7 @@
 {
   "replace": false,
   "values": [
-    "cherryblossomgrotto:cherry_blossom_grotto"
+    "cherryblossomgrotto:cherry_blossom_grotto",
+    "cherryblossomgrotto:cherry_blossom_slopes"
   ]
 }

--- a/src/main/resources/data/forge/tags/worldgen/biome/is_dense/overworld.json
+++ b/src/main/resources/data/forge/tags/worldgen/biome/is_dense/overworld.json
@@ -2,6 +2,7 @@
   "replace": false,
   "values": [
     "cherryblossomgrotto:cherry_blossom_grotto",
-    "cherryblossomgrotto:cherry_blossom_slopes"
+    "cherryblossomgrotto:cherry_blossom_slopes",
+    "cherryblossomgrotto:cherry_blossom_bamboo_jungle"
   ]
 }

--- a/src/main/resources/data/forge/tags/worldgen/biome/is_hot/overworld.json
+++ b/src/main/resources/data/forge/tags/worldgen/biome/is_hot/overworld.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "cherryblossomgrotto:cherry_blossom_bamboo_jungle"
+  ]
+}

--- a/src/main/resources/data/forge/tags/worldgen/biome/is_lush.json
+++ b/src/main/resources/data/forge/tags/worldgen/biome/is_lush.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "cherryblossomgrotto:cherry_blossom_bamboo_jungle"
+  ]
+}

--- a/src/main/resources/data/forge/tags/worldgen/biome/is_overworld.json
+++ b/src/main/resources/data/forge/tags/worldgen/biome/is_overworld.json
@@ -1,6 +1,7 @@
 {
   "replace": false,
   "values": [
-    "cherryblossomgrotto:cherry_blossom_grotto"
+    "cherryblossomgrotto:cherry_blossom_grotto",
+    "cherryblossomgrotto:cherry_blossom_slopes"
   ]
 }

--- a/src/main/resources/data/forge/tags/worldgen/biome/is_overworld.json
+++ b/src/main/resources/data/forge/tags/worldgen/biome/is_overworld.json
@@ -2,6 +2,7 @@
   "replace": false,
   "values": [
     "cherryblossomgrotto:cherry_blossom_grotto",
-    "cherryblossomgrotto:cherry_blossom_slopes"
+    "cherryblossomgrotto:cherry_blossom_slopes",
+    "cherryblossomgrotto:cherry_blossom_bamboo_jungle"
   ]
 }

--- a/src/main/resources/data/forge/tags/worldgen/biome/is_rare.json
+++ b/src/main/resources/data/forge/tags/worldgen/biome/is_rare.json
@@ -1,6 +1,7 @@
 {
   "replace": false,
   "values": [
-    "cherryblossomgrotto:cherry_blossom_grotto"
+    "cherryblossomgrotto:cherry_blossom_grotto",
+    "cherryblossomgrotto:cherry_blossom_slopes"
   ]
 }

--- a/src/main/resources/data/forge/tags/worldgen/biome/is_rare.json
+++ b/src/main/resources/data/forge/tags/worldgen/biome/is_rare.json
@@ -2,6 +2,7 @@
   "replace": false,
   "values": [
     "cherryblossomgrotto:cherry_blossom_grotto",
-    "cherryblossomgrotto:cherry_blossom_slopes"
+    "cherryblossomgrotto:cherry_blossom_slopes",
+    "cherryblossomgrotto:cherry_blossom_bamboo_jungle"
   ]
 }

--- a/src/main/resources/data/forge/tags/worldgen/biome/is_snowy.json
+++ b/src/main/resources/data/forge/tags/worldgen/biome/is_snowy.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "cherryblossomgrotto:cherry_blossom_slopes"
+  ]
+}

--- a/src/main/resources/data/forge/tags/worldgen/biome/is_wet/overworld.json
+++ b/src/main/resources/data/forge/tags/worldgen/biome/is_wet/overworld.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "cherryblossomgrotto:cherry_blossom_bamboo_jungle"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/worldgen/biome/is_forest.json
+++ b/src/main/resources/data/minecraft/tags/worldgen/biome/is_forest.json
@@ -1,6 +1,7 @@
 {
   "replace": false,
   "values": [
-    "cherryblossomgrotto:cherry_blossom_grotto"
+    "cherryblossomgrotto:cherry_blossom_grotto",
+    "cherryblossomgrotto:cherry_blossom_slopes"
   ]
 }

--- a/src/main/resources/data/minecraft/tags/worldgen/biome/is_jungle.json
+++ b/src/main/resources/data/minecraft/tags/worldgen/biome/is_jungle.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "cherryblossomgrotto:cherry_blossom_bamboo_jungle"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/worldgen/biome/is_overworld.json
+++ b/src/main/resources/data/minecraft/tags/worldgen/biome/is_overworld.json
@@ -1,6 +1,7 @@
 {
   "replace": false,
   "values": [
-    "cherryblossomgrotto:cherry_blossom_grotto"
+    "cherryblossomgrotto:cherry_blossom_grotto",
+    "cherryblossomgrotto:cherry_blossom_slopes"
   ]
 }

--- a/src/main/resources/data/minecraft/tags/worldgen/biome/is_overworld.json
+++ b/src/main/resources/data/minecraft/tags/worldgen/biome/is_overworld.json
@@ -2,6 +2,7 @@
   "replace": false,
   "values": [
     "cherryblossomgrotto:cherry_blossom_grotto",
-    "cherryblossomgrotto:cherry_blossom_slopes"
+    "cherryblossomgrotto:cherry_blossom_slopes",
+    "cherryblossomgrotto:cherry_blossom_bamboo_jungle"
   ]
 }

--- a/src/main/resources/data/minecraft/tags/worldgen/biome/is_rare.json
+++ b/src/main/resources/data/minecraft/tags/worldgen/biome/is_rare.json
@@ -1,6 +1,7 @@
 {
   "replace": false,
   "values": [
-    "cherryblossomgrotto:cherry_blossom_grotto"
+    "cherryblossomgrotto:cherry_blossom_grotto",
+    "cherryblossomgrotto:cherry_blossom_slopes"
   ]
 }

--- a/src/main/resources/data/minecraft/tags/worldgen/biome/is_rare.json
+++ b/src/main/resources/data/minecraft/tags/worldgen/biome/is_rare.json
@@ -2,6 +2,7 @@
   "replace": false,
   "values": [
     "cherryblossomgrotto:cherry_blossom_grotto",
-    "cherryblossomgrotto:cherry_blossom_slopes"
+    "cherryblossomgrotto:cherry_blossom_slopes",
+    "cherryblossomgrotto:cherry_blossom_bamboo_jungle"
   ]
 }

--- a/src/main/resources/data/minecraft/tags/worldgen/biome/stronghold_biased_to.json
+++ b/src/main/resources/data/minecraft/tags/worldgen/biome/stronghold_biased_to.json
@@ -1,6 +1,7 @@
 {
   "replace": false,
   "values": [
-    "cherryblossomgrotto:cherry_blossom_grotto"
+    "cherryblossomgrotto:cherry_blossom_grotto",
+    "cherryblossomgrotto:cherry_blossom_slopes"
   ]
 }

--- a/src/main/resources/data/minecraft/tags/worldgen/biome/stronghold_biased_to.json
+++ b/src/main/resources/data/minecraft/tags/worldgen/biome/stronghold_biased_to.json
@@ -2,6 +2,7 @@
   "replace": false,
   "values": [
     "cherryblossomgrotto:cherry_blossom_grotto",
-    "cherryblossomgrotto:cherry_blossom_slopes"
+    "cherryblossomgrotto:cherry_blossom_slopes",
+    "cherryblossomgrotto:cherry_blossom_bamboo_jungle"
   ]
 }


### PR DESCRIPTION
Given that I've been pushing out "beta" builds of this mod for so long I've decided its stable enough that I'm going to mark this as the first non-beta release! Got some more ideas for future features but for now, here's how this release rounds out the mod into its big release:

- Added the new cherry blossom slopes biome! This biome has a sparse forest of cherry blossom trees spawn on snowy mountainsides
- Added the new cherry blossom bamboo jungle biome! This biome is a bamboo jungle interspersed with cherry blossom trees
- Added new surface rules to customize how snow and dirt spawns in the new cherry blossom slopes biome
- Update lots of tags, mostly for biomes, to ensure all modded biomes are associated with the right information
- Reduce the commonality of cherry blossom biomes. They will now spawn much less frequently in vanilla worlds.