### PR TITLE
Fix entity spawn issue in grotto biomes

### DIFF
--- a/src/main/resources/data/cherryblossomgrotto/worldgen/biome/cherry_blossom_grotto.json
+++ b/src/main/resources/data/cherryblossomgrotto/worldgen/biome/cherry_blossom_grotto.json
@@ -132,12 +132,6 @@
       }
     ],
     "water_ambient": [
-      {
-        "type": "cherryblossomgrotto:koi",
-        "weight": 25,
-        "maxCount": 8,
-        "minCount": 8
-      }
     ],
     "misc": [
     ],


### PR DESCRIPTION
Fixes a pretty nasty bug resulting from a bad entity reference in the biome config that caused pigs to continuously spawn in the cherry blossom grotto biome