### PR TITLE
Update for 1.19.4 compatability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
 apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'org.spongepowered.mixin'
 
-version = '1.4.0'
+version = '1.5.0'
 group = 'com.deku.cherryblossomgrotto' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'cherryblossomgrotto'
 
@@ -41,7 +41,7 @@ minecraft {
     //
     // Use non-default mappings at your own risk. They may not always work.
     // Simply re-run your setup task after changing the mappings to update your workspace.
-    mappings channel: 'official', version: '1.19.3'
+    mappings channel: 'official', version: '1.19.4'
 
     // accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg') // Currently, this location cannot be changed from the default.
 
@@ -149,7 +149,7 @@ dependencies {
     // Specify the version of Minecraft to use. If this is any group other than 'net.minecraft', it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency, and its patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft 'net.minecraftforge:forge:1.19.3-44.1.17'
+    minecraft 'net.minecraftforge:forge:1.19.4-45.0.9'
 
     // Real mod deobf dependency examples - these get remapped to your current mappings
     // implementation fg.deobf("com.tterrag.registrate:Registrate:MC${mc_version}-${registrate_version}") // Adds registrate as a dependency
@@ -161,8 +161,8 @@ dependencies {
     // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
 
-    implementation fg.deobf('com.github.glitchfiend:TerraBlender-forge:1.19.3-2.1.0.139')
-    implementation fg.deobf('software.bernie.geckolib:geckolib-forge-1.19.3:4.0.3')
+    implementation fg.deobf('com.github.glitchfiend:TerraBlender-forge:1.19.4-2.2.0.154')
+    implementation fg.deobf('software.bernie.geckolib:geckolib-forge-1.19.4:4.1.0')
 }
 
 // Example for how to get properties into the manifest for reading at runtime.

--- a/src/main/java/com/deku/cherryblossomgrotto/Main.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/Main.java
@@ -56,11 +56,13 @@ import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.animal.AbstractSchoolingFish;
 import net.minecraft.world.entity.animal.WaterAnimal;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.flag.FeatureFlags;
 import net.minecraft.world.item.*;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.RotatedPillarBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockSetType;
 import net.minecraft.world.level.block.state.properties.WoodType;
 import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraftforge.api.distmarker.Dist;
@@ -215,6 +217,9 @@ public class Main
         NETWORK_CHANNEL.registerMessage(DoubleJumpClientMessage.MESSAGE_ID, DoubleJumpClientMessage.class, DoubleJumpClientMessage::encode, DoubleJumpClientMessage::decode, DoubleJumpClientMessageHandler::onMessageReceived, Optional.of(PLAY_TO_CLIENT));
 
         event.enqueueWork(() -> {
+            BlockSetType.register(ModBlockSetType.CHERRY_BLOSSOM);
+            BlockSetType.register(ModBlockSetType.MAPLE);
+
             WoodType.register(ModWoodType.CHERRY_BLOSSOM);
             WoodType.register(ModWoodType.MAPLE);
 
@@ -338,6 +343,7 @@ public class Main
                 registrar.register(new ResourceLocation(MOD_ID, "spruce_planks_trapdoor"), new SprucePlanksTrapdoor());
                 registrar.register(new ResourceLocation(MOD_ID, "birch_planks_trapdoor"), new BirchPlanksTrapdoor());
                 registrar.register(new ResourceLocation(MOD_ID, "mangrove_planks_trapdoor"), new MangrovePlanksTrapdoor());
+                registrar.register(new ResourceLocation(MOD_ID, "bamboo_planks_trapdoor"), new BambooPlanksTrapdoor());
             });
         }
 
@@ -465,6 +471,7 @@ public class Main
                 registrar.register(new ResourceLocation(MOD_ID, "oak_planks_trapdoor"), new BlockItem(ModBlocks.OAK_PLANKS_TRAP_DOOR, new Item.Properties()));
                 registrar.register(new ResourceLocation(MOD_ID, "spruce_planks_trapdoor"), new BlockItem(ModBlocks.SPRUCE_PLANKS_TRAP_DOOR, new Item.Properties()));
                 registrar.register(new ResourceLocation(MOD_ID, "mangrove_planks_trapdoor"), new BlockItem(ModBlocks.MANGROVE_PLANKS_TRAP_DOOR, new Item.Properties()));
+                registrar.register(new ResourceLocation(MOD_ID, "bamboo_planks_trapdoor"), new BlockItem(ModBlocks.BAMBOO_PLANKS_TRAP_DOOR, new Item.Properties().requiredFeatures(FeatureFlags.UPDATE_1_20)));
                 registrar.register(new ResourceLocation(MOD_ID, "smooth_stone_trapdoor"), new BlockItem(ModBlocks.SMOOTH_STONE_TRAP_DOOR, new Item.Properties()));
                 registrar.register(new ResourceLocation(MOD_ID, "stone_trapdoor"), new BlockItem(ModBlocks.STONE_TRAP_DOOR, new Item.Properties()));
                 registrar.register(new ResourceLocation(MOD_ID, "cobblestone_trapdoor"), new BlockItem(ModBlocks.COBBLESTONE_TRAP_DOOR, new Item.Properties()));
@@ -592,104 +599,103 @@ public class Main
             creativeTabBuildRegistryEvent.registerCreativeModeTab(new ResourceLocation(MOD_ID, "cherry_blossom_grotto_creative_tab"), builder ->
                     builder.title(Component.translatable("Cherry Blossom Grotto"))
                             .icon(() -> new ItemStack(ModItems.CHERRY_SAPLING))
-                            .displayItems((enabledFlags, populator, hasPermissions) -> {
+                            .displayItems((displayParams, output) -> {
                                         // Cherry blossom blocks
-                                        populator.accept(ModItems.CHERRY_LOG);
-                                        populator.accept(ModItems.CHERRY_WOOD);
-                                        populator.accept(ModItems.STRIPPED_CHERRY_LOG);
-                                        populator.accept(ModItems.STRIPPED_CHERRY_WOOD);
-                                        populator.accept(ModItems.CHERRY_PLANKS);
-                                        populator.accept(ModItems.CHERRY_STAIRS);
-                                        populator.accept(ModItems.CHERRY_SLAB);
-                                        populator.accept(ModItems.CHERRY_FENCE);
-                                        populator.accept(ModItems.CHERRY_FENCE_GATE);
-                                        populator.accept(ModItems.CHERRY_DOOR);
-                                        populator.accept(ModItems.CHERRY_TRAPDOOR);
-                                        populator.accept(ModItems.CHERRY_PRESSURE_PLATE);
-                                        populator.accept(ModItems.CHERRY_LOG);
-                                        populator.accept(ModItems.CHERRY_BUTTON);
-                                        populator.accept(ModItems.CHERRY_LEAVES);
-                                        populator.accept(ModItems.CHERRY_SAPLING);
-                                        populator.accept(new ItemStack(ModItems.CHERRY_PETAL));
-                                        populator.accept(ModItems.CHERRY_PETALS);
-                                        populator.accept(new ItemStack(ModItems.CHERRY_BOAT));
-                                        populator.accept(new ItemStack(ModItems.CHERRY_CHEST_BOAT));
-                                        populator.accept(ModItems.CHERRY_SIGN);
-                                        populator.accept(ModItems.CHERRY_HANGING_SIGN);
+                                        output.accept(ModItems.CHERRY_LOG);
+                                        output.accept(ModItems.CHERRY_WOOD);
+                                        output.accept(ModItems.STRIPPED_CHERRY_LOG);
+                                        output.accept(ModItems.STRIPPED_CHERRY_WOOD);
+                                        output.accept(ModItems.CHERRY_PLANKS);
+                                        output.accept(ModItems.CHERRY_STAIRS);
+                                        output.accept(ModItems.CHERRY_SLAB);
+                                        output.accept(ModItems.CHERRY_FENCE);
+                                        output.accept(ModItems.CHERRY_FENCE_GATE);
+                                        output.accept(ModItems.CHERRY_DOOR);
+                                        output.accept(ModItems.CHERRY_TRAPDOOR);
+                                        output.accept(ModItems.CHERRY_PRESSURE_PLATE);
+                                        output.accept(ModItems.CHERRY_BUTTON);
+                                        output.accept(ModItems.CHERRY_LEAVES);
+                                        output.accept(ModItems.CHERRY_SAPLING);
+                                        output.accept(new ItemStack(ModItems.CHERRY_PETAL));
+                                        output.accept(ModItems.CHERRY_PETALS);
+                                        output.accept(new ItemStack(ModItems.CHERRY_BOAT));
+                                        output.accept(new ItemStack(ModItems.CHERRY_CHEST_BOAT));
+                                        output.accept(ModItems.CHERRY_SIGN);
+                                        output.accept(ModItems.CHERRY_HANGING_SIGN);
 
                                         // Maple blocks
-                                        populator.accept(ModItems.MAPLE_LOG);
-                                        populator.accept(ModItems.MAPLE_WOOD);
-                                        populator.accept(ModItems.STRIPPED_MAPLE_LOG);
-                                        populator.accept(ModItems.STRIPPED_MAPLE_WOOD);
-                                        populator.accept(ModItems.MAPLE_PLANKS);
-                                        populator.accept(ModItems.MAPLE_STAIRS);
-                                        populator.accept(ModItems.MAPLE_SLAB);
-                                        populator.accept(ModItems.MAPLE_FENCE);
-                                        populator.accept(ModItems.MAPLE_FENCE_GATE);
-                                        populator.accept(ModItems.MAPLE_DOOR);
-                                        populator.accept(ModItems.MAPLE_TRAPDOOR);
-                                        populator.accept(ModItems.MAPLE_PRESSURE_PLATE);
-                                        populator.accept(ModItems.MAPLE_LOG);
-                                        populator.accept(ModItems.MAPLE_BUTTON);
-                                        populator.accept(ModItems.MAPLE_LEAVES);
-                                        populator.accept(ModItems.MAPLE_SAPLING);
-                                        populator.accept(new ItemStack(ModItems.MAPLE_LEAF));
-                                        populator.accept(ModItems.MAPLE_LEAF_PILE);
-                                        populator.accept(new ItemStack(ModItems.MAPLE_BOAT));
-                                        populator.accept(new ItemStack(ModItems.MAPLE_CHEST_BOAT));
-                                        populator.accept(ModItems.MAPLE_SIGN);
-                                        populator.accept(ModItems.MAPLE_HANGING_SIGN);
+                                        output.accept(ModItems.MAPLE_LOG);
+                                        output.accept(ModItems.MAPLE_WOOD);
+                                        output.accept(ModItems.STRIPPED_MAPLE_LOG);
+                                        output.accept(ModItems.STRIPPED_MAPLE_WOOD);
+                                        output.accept(ModItems.MAPLE_PLANKS);
+                                        output.accept(ModItems.MAPLE_STAIRS);
+                                        output.accept(ModItems.MAPLE_SLAB);
+                                        output.accept(ModItems.MAPLE_FENCE);
+                                        output.accept(ModItems.MAPLE_FENCE_GATE);
+                                        output.accept(ModItems.MAPLE_DOOR);
+                                        output.accept(ModItems.MAPLE_TRAPDOOR);
+                                        output.accept(ModItems.MAPLE_PRESSURE_PLATE);
+                                        output.accept(ModItems.MAPLE_BUTTON);
+                                        output.accept(ModItems.MAPLE_LEAVES);
+                                        output.accept(ModItems.MAPLE_SAPLING);
+                                        output.accept(new ItemStack(ModItems.MAPLE_LEAF));
+                                        output.accept(ModItems.MAPLE_LEAF_PILE);
+                                        output.accept(new ItemStack(ModItems.MAPLE_BOAT));
+                                        output.accept(new ItemStack(ModItems.MAPLE_CHEST_BOAT));
+                                        output.accept(ModItems.MAPLE_SIGN);
+                                        output.accept(ModItems.MAPLE_HANGING_SIGN);
 
                                         // Crops
-                                        populator.accept(new ItemStack(ModItems.RICE));
-                                        populator.accept(new ItemStack(ModItems.ONIGIRI));
-                                        populator.accept(new ItemStack(ModItems.MAPLE_SYRUP_BOTTLE));
+                                        output.accept(new ItemStack(ModItems.RICE));
+                                        output.accept(new ItemStack(ModItems.ONIGIRI));
+                                        output.accept(new ItemStack(ModItems.MAPLE_SYRUP_BOTTLE));
 
                                         // Wildlife
-                                        populator.accept(new ItemStack(ModItems.KOI));
-                                        populator.accept(new ItemStack(ModItems.COOKED_KOI));
-                                        populator.accept(new ItemStack(ModItems.KOI_BUCKET));
-                                        populator.accept(new ItemStack(ModItems.KOI_SPAWN_EGG));
-                                        populator.accept(new ItemStack(ModItems.TANOOKI_SPAWN_EGG));
+                                        output.accept(new ItemStack(ModItems.KOI));
+                                        output.accept(new ItemStack(ModItems.COOKED_KOI));
+                                        output.accept(new ItemStack(ModItems.KOI_BUCKET));
+                                        output.accept(new ItemStack(ModItems.KOI_SPAWN_EGG));
+                                        output.accept(new ItemStack(ModItems.TANOOKI_SPAWN_EGG));
 
                                         // Misc building blocks
-                                        populator.accept(ModItems.SHOJI_SCREEN);
-                                        populator.accept(ModItems.TATAMI_MAT);
-                                        populator.accept(ModItems.LONG_TATAMI_MAT);
-                                        populator.accept(ModItems.AGED_TATAMI_MAT);
-                                        populator.accept(ModItems.LONG_AGED_TATAMI_MAT);
-                                        populator.accept(ModItems.ZEN_LANTERN);
-                                        populator.accept(ModItems.SOUL_ZEN_LANTERN);
-                                        populator.accept(ModItems.PAPER_LANTERN);
+                                        output.accept(ModItems.SHOJI_SCREEN);
+                                        output.accept(ModItems.TATAMI_MAT);
+                                        output.accept(ModItems.LONG_TATAMI_MAT);
+                                        output.accept(ModItems.AGED_TATAMI_MAT);
+                                        output.accept(ModItems.LONG_AGED_TATAMI_MAT);
+                                        output.accept(ModItems.ZEN_LANTERN);
+                                        output.accept(ModItems.SOUL_ZEN_LANTERN);
+                                        output.accept(ModItems.PAPER_LANTERN);
 
                                         // Weapons & Armour
-                                        populator.accept(new ItemStack(ModItems.KATANA));
-                                        populator.accept(new ItemStack(ModItems.KUNAI));
-                                        populator.accept(new ItemStack(ModItems.SHURIKEN));
-                                        populator.accept(new ItemStack(ModItems.NINJA_MASK));
-                                        populator.accept(new ItemStack(ModItems.NINJA_TUNIC));
-                                        populator.accept(new ItemStack(ModItems.NINJA_LEGGINGS));
-                                        populator.accept(new ItemStack(ModItems.NINJA_SANDALS));
-                                        populator.accept(new ItemStack(ModItems.KABUTO_HELMET));
-                                        populator.accept(new ItemStack(ModItems.KABUTO_CUIRASS));
-                                        populator.accept(new ItemStack(ModItems.KABUTO_GREAVES));
-                                        populator.accept(new ItemStack(ModItems.KABUTO_SANDALS));
+                                        output.accept(new ItemStack(ModItems.KATANA));
+                                        output.accept(new ItemStack(ModItems.KUNAI));
+                                        output.accept(new ItemStack(ModItems.SHURIKEN));
+                                        output.accept(new ItemStack(ModItems.NINJA_MASK));
+                                        output.accept(new ItemStack(ModItems.NINJA_TUNIC));
+                                        output.accept(new ItemStack(ModItems.NINJA_LEGGINGS));
+                                        output.accept(new ItemStack(ModItems.NINJA_SANDALS));
+                                        output.accept(new ItemStack(ModItems.KABUTO_HELMET));
+                                        output.accept(new ItemStack(ModItems.KABUTO_CUIRASS));
+                                        output.accept(new ItemStack(ModItems.KABUTO_GREAVES));
+                                        output.accept(new ItemStack(ModItems.KABUTO_SANDALS));
 
                                         // Hidden trapdoors
-                                        populator.accept(ModItems.CHERRY_BLOSSOM_PLANKS_TRAP_DOOR);
-                                        populator.accept(ModItems.MAPLE_PLANKS_TRAP_DOOR);
-                                        populator.accept(ModItems.ACACIA_PLANKS_TRAP_DOOR);
-                                        populator.accept(ModItems.BIRCH_PLANKS_TRAP_DOOR);
-                                        populator.accept(ModItems.DARK_OAK_PLANKS_TRAP_DOOR);
-                                        populator.accept(ModItems.JUNGLE_PLANKS_TRAP_DOOR);
-                                        populator.accept(ModItems.OAK_PLANKS_TRAP_DOOR);
-                                        populator.accept(ModItems.SPRUCE_PLANKS_TRAP_DOOR);
-                                        populator.accept(ModItems.MANGROVE_PLANKS_TRAP_DOOR);
-                                        populator.accept(ModItems.SMOOTH_STONE_TRAP_DOOR);
-                                        populator.accept(ModItems.STONE_TRAP_DOOR);
-                                        populator.accept(ModItems.SMOOTH_STONE_TRAP_DOOR);
-                                        populator.accept(ModItems.COBBLESTONE_TRAP_DOOR);
+                                        output.accept(ModItems.CHERRY_BLOSSOM_PLANKS_TRAP_DOOR);
+                                        output.accept(ModItems.MAPLE_PLANKS_TRAP_DOOR);
+                                        output.accept(ModItems.ACACIA_PLANKS_TRAP_DOOR);
+                                        output.accept(ModItems.BIRCH_PLANKS_TRAP_DOOR);
+                                        output.accept(ModItems.DARK_OAK_PLANKS_TRAP_DOOR);
+                                        output.accept(ModItems.JUNGLE_PLANKS_TRAP_DOOR);
+                                        output.accept(ModItems.OAK_PLANKS_TRAP_DOOR);
+                                        output.accept(ModItems.SPRUCE_PLANKS_TRAP_DOOR);
+                                        output.accept(ModItems.MANGROVE_PLANKS_TRAP_DOOR);
+                                        output.accept(ModItems.BAMBOO_PLANKS_TRAP_DOOR);
+                                        output.accept(ModItems.SMOOTH_STONE_TRAP_DOOR);
+                                        output.accept(ModItems.STONE_TRAP_DOOR);
+                                        output.accept(ModItems.SMOOTH_STONE_TRAP_DOOR);
+                                        output.accept(ModItems.COBBLESTONE_TRAP_DOOR);
                                     }
                             )
             );
@@ -721,6 +727,7 @@ public class Main
                 entries.putAfter(new ItemStack(ModItems.CHERRY_TRAPDOOR), new ItemStack(ModItems.CHERRY_PRESSURE_PLATE), visibility);
                 entries.putAfter(new ItemStack(ModItems.CHERRY_PRESSURE_PLATE), new ItemStack(ModItems.CHERRY_BUTTON), visibility);
 
+                entries.putAfter(new ItemStack(ModItems.CHERRY_PRESSURE_PLATE), new ItemStack(ModItems.MAPLE_LOG), visibility);
                 entries.putAfter(new ItemStack(ModItems.MAPLE_LOG), new ItemStack(ModItems.MAPLE_WOOD), visibility);
                 entries.putAfter(new ItemStack(ModItems.MAPLE_WOOD), new ItemStack(ModItems.STRIPPED_MAPLE_LOG), visibility);
                 entries.putAfter(new ItemStack(ModItems.STRIPPED_MAPLE_LOG), new ItemStack(ModItems.STRIPPED_MAPLE_WOOD), visibility);
@@ -749,6 +756,7 @@ public class Main
                 entries.putAfter(new ItemStack(Items.OAK_TRAPDOOR), new ItemStack(ModItems.OAK_PLANKS_TRAP_DOOR), visibility);
                 entries.putAfter(new ItemStack(Items.SPRUCE_TRAPDOOR), new ItemStack(ModItems.SPRUCE_PLANKS_TRAP_DOOR), visibility);
                 entries.putAfter(new ItemStack(Items.MANGROVE_TRAPDOOR), new ItemStack(ModItems.MANGROVE_PLANKS_TRAP_DOOR), visibility);
+                entries.putAfter(new ItemStack(Items.BAMBOO_TRAPDOOR), new ItemStack(ModItems.BAMBOO_PLANKS_TRAP_DOOR), visibility);
                 entries.putAfter(new ItemStack(ModItems.CHERRY_TRAPDOOR), new ItemStack(ModItems.CHERRY_BLOSSOM_PLANKS_TRAP_DOOR), visibility);
                 entries.putAfter(new ItemStack(ModItems.MAPLE_TRAPDOOR), new ItemStack(ModItems.MAPLE_PLANKS_TRAP_DOOR), visibility);
                 entries.putAfter(new ItemStack(Items.STONE_SLAB), new ItemStack(ModItems.STONE_TRAP_DOOR), visibility);
@@ -762,6 +770,8 @@ public class Main
                 entries.putAfter(new ItemStack(Items.SWEET_BERRIES), new ItemStack(ModItems.RICE), visibility);
                 entries.putAfter(new ItemStack(ModItems.RICE), new ItemStack(ModItems.CHERRY_PETAL), visibility);
                 entries.putAfter(new ItemStack(ModItems.CHERRY_PETAL), new ItemStack(ModItems.CHERRY_PETALS), visibility);
+
+                // Maple blocks
                 entries.putAfter(new ItemStack(ModItems.CHERRY_LOG), new ItemStack(ModItems.MAPLE_LOG), visibility);
                 entries.putAfter(new ItemStack(ModItems.CHERRY_LEAVES), new ItemStack(ModItems.MAPLE_LEAVES), visibility);
                 entries.putAfter(new ItemStack(ModItems.CHERRY_SAPLING), new ItemStack(ModItems.MAPLE_SAPLING), visibility);

--- a/src/main/java/com/deku/cherryblossomgrotto/client/renderers/layers/KabutoArmourLayer.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/client/renderers/layers/KabutoArmourLayer.java
@@ -3,6 +3,7 @@ package com.deku.cherryblossomgrotto.client.renderers.layers;
 import com.deku.cherryblossomgrotto.client.models.InnerKabutoArmourModel;
 import com.deku.cherryblossomgrotto.client.models.KabutoArmourModel;
 import com.deku.cherryblossomgrotto.client.models.geom.ModModelLayerLocations;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.client.model.geom.EntityModelSet;
 import net.minecraft.client.renderer.entity.RenderLayerParent;
@@ -17,7 +18,7 @@ public class KabutoArmourLayer<T extends LivingEntity, M extends HumanoidModel<T
     public static InnerKabutoArmourModel INNER_MODEL;
 
     public KabutoArmourLayer(RenderLayerParent<T, M> armourRenderer, EntityModelSet modelSet) {
-        super(armourRenderer, (A) new InnerKabutoArmourModel(modelSet.bakeLayer(ModModelLayerLocations.INNER_KABUTO_ARMOUR)), (A) new KabutoArmourModel(modelSet.bakeLayer(ModModelLayerLocations.KABUTO_ARMOUR)));
+        super(armourRenderer, (A) new InnerKabutoArmourModel(modelSet.bakeLayer(ModModelLayerLocations.INNER_KABUTO_ARMOUR)), (A) new KabutoArmourModel(modelSet.bakeLayer(ModModelLayerLocations.KABUTO_ARMOUR)), Minecraft.getInstance().getModelManager());
 
         INNER_MODEL = (InnerKabutoArmourModel) this.innerModel;
         MODEL = (KabutoArmourModel) this.outerModel;

--- a/src/main/java/com/deku/cherryblossomgrotto/client/renderers/layers/NinjaRobesLayer.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/client/renderers/layers/NinjaRobesLayer.java
@@ -3,6 +3,7 @@ package com.deku.cherryblossomgrotto.client.renderers.layers;
 import com.deku.cherryblossomgrotto.client.models.InnerNinjaRobesModel;
 import com.deku.cherryblossomgrotto.client.models.NinjaRobesModel;
 import com.deku.cherryblossomgrotto.client.models.geom.ModModelLayerLocations;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.client.model.geom.EntityModelSet;
 import net.minecraft.client.renderer.entity.RenderLayerParent;
@@ -17,7 +18,7 @@ public class NinjaRobesLayer<T extends LivingEntity, M extends HumanoidModel<T>,
     public static InnerNinjaRobesModel INNER_MODEL;
 
     public NinjaRobesLayer(RenderLayerParent<T, M> armourRenderer, EntityModelSet modelSet) {
-        super(armourRenderer, (A) new InnerNinjaRobesModel(modelSet.bakeLayer(ModModelLayerLocations.INNER_NINJA_ROBES)), (A) new NinjaRobesModel(modelSet.bakeLayer(ModModelLayerLocations.NINJA_ROBES)));
+        super(armourRenderer, (A) new InnerNinjaRobesModel(modelSet.bakeLayer(ModModelLayerLocations.INNER_NINJA_ROBES)), (A) new NinjaRobesModel(modelSet.bakeLayer(ModModelLayerLocations.NINJA_ROBES)), Minecraft.getInstance().getModelManager());
 
         INNER_MODEL = (InnerNinjaRobesModel) this.innerModel;
         MODEL = (NinjaRobesModel) this.outerModel;

--- a/src/main/java/com/deku/cherryblossomgrotto/common/blocks/AbstractFallingLeavesBlock.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/blocks/AbstractFallingLeavesBlock.java
@@ -1,73 +1,10 @@
 package com.deku.cherryblossomgrotto.common.blocks;
 
-import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
-import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.EntityBlock;
-import net.minecraft.world.level.block.LeavesBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.common.extensions.IForgeBlock;
 
-public abstract class AbstractFallingLeavesBlock extends LeavesBlock implements IForgeBlock, EntityBlock {
+public abstract class AbstractFallingLeavesBlock extends AbstractLeavesBlock implements EntityBlock {
     public AbstractFallingLeavesBlock(BlockBehaviour.Properties properties) {
         super(properties);
-    }
-
-    /**
-     * A false predicate that is used to ensure that the leaves block does not suffocate an entity if the entity spawns within it
-     *
-     * @return Block behaviour indicating returning false
-     */
-    protected static BlockBehaviour.StatePredicate never() {
-        BlockBehaviour.StatePredicate statePredicate = (p_152641_, p_152642_, p_152643_) -> false;
-        return statePredicate;
-    }
-
-    /**
-     * Ensures that ocelots and parrots can still spawn on these leave blocks.
-     * Re-implementation of privatized logic in vanilla code that is passed into the constructor for all leaves blocks
-     *
-     * @param blockState State of the block
-     * @param blockGetter Getter for the block
-     * @param blockPos Position of the block in the level
-     * @param entityType Entity type that is attempting to spawn on this block
-     * @return Whether this entity can spawn on this block
-     */
-    protected static boolean validSpawns(BlockState blockState, BlockGetter blockGetter, BlockPos blockPos, EntityType<?> entityType) {
-        return entityType == EntityType.OCELOT || entityType == EntityType.PARROT;
-    }
-
-    /**
-     * Determines the flammability of the block
-     * The higher the number the more likely it is to catch fire
-     *
-     * @param state State of the block being burned
-     * @param blockGetter Getter for the block being burned
-     * @param position Position of the block being burned
-     * @param face Face of the block that is being burned
-     * @return The flammability of this block
-     */
-    @Override
-    public int getFlammability(BlockState state, BlockGetter blockGetter, BlockPos position, Direction face)
-    {
-        return 5;
-    }
-
-    /**
-     * Determines the likelihood that fire will spread to this block
-     * The higher the number the more likely it is to burn up.
-     *
-     * @param state State of the block being burned
-     * @param blockGetter Getter for the block being burned
-     * @param position Position of the block being burned
-     * @param face Face of the block that is being burned
-     * @return The likelihood that fire will spread to this block
-     */
-    @Override
-    public int getFireSpreadSpeed(BlockState state, BlockGetter blockGetter, BlockPos position, Direction face)
-    {
-        return 20;
     }
 }

--- a/src/main/java/com/deku/cherryblossomgrotto/common/blocks/AbstractLeavesBlock.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/blocks/AbstractLeavesBlock.java
@@ -1,0 +1,72 @@
+package com.deku.cherryblossomgrotto.common.blocks;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.LeavesBlock;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.common.extensions.IForgeBlock;
+
+public abstract class AbstractLeavesBlock extends LeavesBlock implements IForgeBlock {
+    public AbstractLeavesBlock(BlockBehaviour.Properties properties) {
+        super(properties);
+    }
+
+    /**
+     * A false predicate that is used to ensure that the leaves block does not suffocate an entity if the entity spawns within it
+     *
+     * @return Block behaviour indicating returning false
+     */
+    protected static BlockBehaviour.StatePredicate never() {
+        BlockBehaviour.StatePredicate statePredicate = (p_152641_, p_152642_, p_152643_) -> false;
+        return statePredicate;
+    }
+
+    /**
+     * Ensures that ocelots and parrots can still spawn on these leave blocks.
+     * Re-implementation of privatized logic in vanilla code that is passed into the constructor for all leaves blocks
+     *
+     * @param blockState State of the block
+     * @param blockGetter Getter for the block
+     * @param blockPos Position of the block in the level
+     * @param entityType Entity type that is attempting to spawn on this block
+     * @return Whether this entity can spawn on this block
+     */
+    protected static boolean validSpawns(BlockState blockState, BlockGetter blockGetter, BlockPos blockPos, EntityType<?> entityType) {
+        return entityType == EntityType.OCELOT || entityType == EntityType.PARROT;
+    }
+
+    /**
+     * Determines the flammability of the block
+     * The higher the number the more likely it is to catch fire
+     *
+     * @param state State of the block being burned
+     * @param blockGetter Getter for the block being burned
+     * @param position Position of the block being burned
+     * @param face Face of the block that is being burned
+     * @return The flammability of this block
+     */
+    @Override
+    public int getFlammability(BlockState state, BlockGetter blockGetter, BlockPos position, Direction face)
+    {
+        return 5;
+    }
+
+    /**
+     * Determines the likelihood that fire will spread to this block
+     * The higher the number the more likely it is to burn up.
+     *
+     * @param state State of the block being burned
+     * @param blockGetter Getter for the block being burned
+     * @param position Position of the block being burned
+     * @param face Face of the block that is being burned
+     * @return The likelihood that fire will spread to this block
+     */
+    @Override
+    public int getFireSpreadSpeed(BlockState state, BlockGetter blockGetter, BlockPos position, Direction face)
+    {
+        return 20;
+    }
+}

--- a/src/main/java/com/deku/cherryblossomgrotto/common/blocks/AcaciaPlanksTrapdoor.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/blocks/AcaciaPlanksTrapdoor.java
@@ -1,18 +1,17 @@
 package com.deku.cherryblossomgrotto.common.blocks;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.TrapDoorBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockSetType;
 import net.minecraft.world.level.material.Material;
 
 public class AcaciaPlanksTrapdoor extends TrapDoorBlock {
     public AcaciaPlanksTrapdoor() {
-        super(Properties.of(Material.WOOD, Blocks.ACACIA_PLANKS.defaultMaterialColor()).strength( 3.0f).sound(SoundType.WOOD).noOcclusion().isValidSpawn(AcaciaPlanksTrapdoor::never), SoundEvents.WOODEN_TRAPDOOR_CLOSE, SoundEvents.WOODEN_TRAPDOOR_OPEN);
+        super(Properties.of(Material.WOOD, Blocks.ACACIA_PLANKS.defaultMaterialColor()).strength( 3.0f).noOcclusion().isValidSpawn(AcaciaPlanksTrapdoor::never), BlockSetType.ACACIA);
     }
 
     /**

--- a/src/main/java/com/deku/cherryblossomgrotto/common/blocks/BambooPlanksTrapdoor.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/blocks/BambooPlanksTrapdoor.java
@@ -2,6 +2,7 @@ package com.deku.cherryblossomgrotto.common.blocks;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.flag.FeatureFlags;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.TrapDoorBlock;
@@ -9,9 +10,9 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockSetType;
 import net.minecraft.world.level.material.Material;
 
-public class MangrovePlanksTrapdoor extends TrapDoorBlock {
-    public MangrovePlanksTrapdoor() {
-        super(Properties.of(Material.WOOD, Blocks.MANGROVE_PLANKS.defaultMaterialColor()).strength( 3.0f).noOcclusion().isValidSpawn(MangrovePlanksTrapdoor::never), BlockSetType.MANGROVE);
+public class BambooPlanksTrapdoor extends TrapDoorBlock {
+    public BambooPlanksTrapdoor() {
+        super(Properties.of(Material.WOOD, Blocks.BAMBOO_PLANKS.defaultMaterialColor()).strength(3.0f).noOcclusion().isValidSpawn(BambooPlanksTrapdoor::never).requiredFeatures(FeatureFlags.UPDATE_1_20), BlockSetType.BAMBOO);
     }
 
     /**

--- a/src/main/java/com/deku/cherryblossomgrotto/common/blocks/BirchPlanksTrapdoor.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/blocks/BirchPlanksTrapdoor.java
@@ -1,18 +1,17 @@
 package com.deku.cherryblossomgrotto.common.blocks;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.TrapDoorBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockSetType;
 import net.minecraft.world.level.material.Material;
 
 public class BirchPlanksTrapdoor extends TrapDoorBlock {
     public BirchPlanksTrapdoor() {
-        super(Properties.of(Material.WOOD, Blocks.BIRCH_PLANKS.defaultMaterialColor()).strength( 3.0f).sound(SoundType.WOOD).noOcclusion().isValidSpawn(BirchPlanksTrapdoor::never), SoundEvents.WOODEN_TRAPDOOR_CLOSE, SoundEvents.WOODEN_TRAPDOOR_OPEN);
+        super(Properties.of(Material.WOOD, Blocks.BIRCH_PLANKS.defaultMaterialColor()).strength( 3.0f).noOcclusion().isValidSpawn(BirchPlanksTrapdoor::never), BlockSetType.BIRCH);
     }
 
     /**

--- a/src/main/java/com/deku/cherryblossomgrotto/common/blocks/CobblestoneTrapdoor.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/blocks/CobblestoneTrapdoor.java
@@ -1,19 +1,18 @@
 package com.deku.cherryblossomgrotto.common.blocks;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.TrapDoorBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockSetType;
 import net.minecraft.world.level.material.Material;
 
 public class CobblestoneTrapdoor extends TrapDoorBlock {
     public CobblestoneTrapdoor() {
-        super(BlockBehaviour.Properties.of(Material.STONE, Blocks.COBBLESTONE.defaultMaterialColor()).strength(6.0f).sound(SoundType.STONE).noOcclusion().isValidSpawn(CobblestoneTrapdoor::never), SoundEvents.WOODEN_TRAPDOOR_CLOSE, SoundEvents.WOODEN_TRAPDOOR_OPEN);
+        super(BlockBehaviour.Properties.of(Material.STONE, Blocks.COBBLESTONE.defaultMaterialColor()).strength(6.0f).noOcclusion().isValidSpawn(CobblestoneTrapdoor::never), BlockSetType.STONE);
     }
 
     /**

--- a/src/main/java/com/deku/cherryblossomgrotto/common/blocks/DarkOakPlanksTrapdoor.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/blocks/DarkOakPlanksTrapdoor.java
@@ -1,18 +1,17 @@
 package com.deku.cherryblossomgrotto.common.blocks;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.TrapDoorBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockSetType;
 import net.minecraft.world.level.material.Material;
 
 public class DarkOakPlanksTrapdoor extends TrapDoorBlock {
     public DarkOakPlanksTrapdoor() {
-        super(Properties.of(Material.WOOD, Blocks.DARK_OAK_PLANKS.defaultMaterialColor()).strength( 3.0f).sound(SoundType.WOOD).noOcclusion().isValidSpawn(DarkOakPlanksTrapdoor::never), SoundEvents.WOODEN_TRAPDOOR_CLOSE, SoundEvents.WOODEN_TRAPDOOR_OPEN);
+        super(Properties.of(Material.WOOD, Blocks.DARK_OAK_PLANKS.defaultMaterialColor()).strength( 3.0f).noOcclusion().isValidSpawn(DarkOakPlanksTrapdoor::never), BlockSetType.DARK_OAK);
     }
 
     /**

--- a/src/main/java/com/deku/cherryblossomgrotto/common/blocks/JunglePlanksTrapdoor.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/blocks/JunglePlanksTrapdoor.java
@@ -1,18 +1,17 @@
 package com.deku.cherryblossomgrotto.common.blocks;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.TrapDoorBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockSetType;
 import net.minecraft.world.level.material.Material;
 
 public class JunglePlanksTrapdoor extends TrapDoorBlock {
     public JunglePlanksTrapdoor() {
-        super(Properties.of(Material.WOOD, Blocks.JUNGLE_PLANKS.defaultMaterialColor()).strength( 3.0f).sound(SoundType.WOOD).noOcclusion().isValidSpawn(JunglePlanksTrapdoor::never), SoundEvents.WOODEN_TRAPDOOR_CLOSE, SoundEvents.WOODEN_TRAPDOOR_OPEN);
+        super(Properties.of(Material.WOOD, Blocks.JUNGLE_PLANKS.defaultMaterialColor()).strength( 3.0f).noOcclusion().isValidSpawn(JunglePlanksTrapdoor::never), BlockSetType.JUNGLE);
     }
 
     /**

--- a/src/main/java/com/deku/cherryblossomgrotto/common/blocks/ModBlockSetType.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/blocks/ModBlockSetType.java
@@ -1,0 +1,13 @@
+package com.deku.cherryblossomgrotto.common.blocks;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.world.level.block.SoundType;
+import net.minecraft.world.level.block.state.properties.BlockSetType;
+
+import static com.deku.cherryblossomgrotto.Main.MOD_ID;
+
+public class ModBlockSetType {
+    public static BlockSetType CHERRY_BLOSSOM = new BlockSetType(new ResourceLocation(MOD_ID, "cherry_blossom").toString(), SoundType.CHERRY_WOOD, SoundEvents.CHERRY_WOOD_DOOR_CLOSE, SoundEvents.CHERRY_WOOD_DOOR_OPEN, SoundEvents.CHERRY_WOOD_TRAPDOOR_CLOSE, SoundEvents.CHERRY_WOOD_TRAPDOOR_OPEN, SoundEvents.CHERRY_WOOD_PRESSURE_PLATE_CLICK_OFF, SoundEvents.CHERRY_WOOD_PRESSURE_PLATE_CLICK_ON, SoundEvents.CHERRY_WOOD_BUTTON_CLICK_OFF, SoundEvents.CHERRY_WOOD_BUTTON_CLICK_ON);
+    public static BlockSetType MAPLE = new BlockSetType(new ResourceLocation(MOD_ID, "maple").toString());
+}

--- a/src/main/java/com/deku/cherryblossomgrotto/common/blocks/ModBlocks.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/blocks/ModBlocks.java
@@ -188,6 +188,9 @@ public class ModBlocks {
     @ObjectHolder(registryName = "minecraft:block", value = MOD_ID + ":mangrove_planks_trapdoor")
     public static MangrovePlanksTrapdoor MANGROVE_PLANKS_TRAP_DOOR;
 
+    @ObjectHolder(registryName = "minecraft:block", value = MOD_ID + ":bamboo_planks_trapdoor")
+    public static BambooPlanksTrapdoor BAMBOO_PLANKS_TRAP_DOOR;
+
     @ObjectHolder(registryName = "minecraft:block", value = MOD_ID + ":smooth_stone_trapdoor")
     public static SmoothStoneTrapdoor SMOOTH_STONE_TRAP_DOOR;
 

--- a/src/main/java/com/deku/cherryblossomgrotto/common/blocks/ModWoodType.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/blocks/ModWoodType.java
@@ -6,6 +6,6 @@ import net.minecraft.world.level.block.state.properties.WoodType;
 import static com.deku.cherryblossomgrotto.Main.MOD_ID;
 
 public class ModWoodType {
-    public static WoodType CHERRY_BLOSSOM = WoodType.create(new ResourceLocation(MOD_ID, "cherry_blossom").toString());
-    public static WoodType MAPLE = WoodType.create(new ResourceLocation(MOD_ID, "maple").toString());
+    public static WoodType CHERRY_BLOSSOM = new WoodType(new ResourceLocation(MOD_ID, "cherry_blossom").toString(), ModBlockSetType.CHERRY_BLOSSOM);
+    public static WoodType MAPLE = new WoodType(new ResourceLocation(MOD_ID, "maple").toString(), ModBlockSetType.MAPLE);
 }

--- a/src/main/java/com/deku/cherryblossomgrotto/common/blocks/OakPlanksTrapdoor.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/blocks/OakPlanksTrapdoor.java
@@ -1,18 +1,17 @@
 package com.deku.cherryblossomgrotto.common.blocks;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.TrapDoorBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockSetType;
 import net.minecraft.world.level.material.Material;
 
 public class OakPlanksTrapdoor extends TrapDoorBlock {
     public OakPlanksTrapdoor() {
-        super(Properties.of(Material.WOOD, Blocks.OAK_PLANKS.defaultMaterialColor()).strength( 3.0f).sound(SoundType.WOOD).noOcclusion().isValidSpawn(OakPlanksTrapdoor::never), SoundEvents.WOODEN_TRAPDOOR_CLOSE, SoundEvents.WOODEN_TRAPDOOR_OPEN);
+        super(Properties.of(Material.WOOD, Blocks.OAK_PLANKS.defaultMaterialColor()).strength( 3.0f).noOcclusion().isValidSpawn(OakPlanksTrapdoor::never), BlockSetType.OAK);
     }
 
     /**

--- a/src/main/java/com/deku/cherryblossomgrotto/common/blocks/SmoothStoneTrapdoor.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/blocks/SmoothStoneTrapdoor.java
@@ -1,19 +1,18 @@
 package com.deku.cherryblossomgrotto.common.blocks;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.TrapDoorBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockSetType;
 import net.minecraft.world.level.material.Material;
 
 public class SmoothStoneTrapdoor extends TrapDoorBlock {
     public SmoothStoneTrapdoor() {
-        super(BlockBehaviour.Properties.of(Material.STONE, Blocks.SMOOTH_STONE.defaultMaterialColor()).strength(6.0f).sound(SoundType.STONE).noOcclusion().isValidSpawn(SmoothStoneTrapdoor::never), SoundEvents.WOODEN_TRAPDOOR_CLOSE, SoundEvents.WOODEN_TRAPDOOR_OPEN);
+        super(BlockBehaviour.Properties.of(Material.STONE, Blocks.SMOOTH_STONE.defaultMaterialColor()).strength(6.0f).noOcclusion().isValidSpawn(SmoothStoneTrapdoor::never), BlockSetType.STONE);
     }
 
     /**

--- a/src/main/java/com/deku/cherryblossomgrotto/common/blocks/SprucePlanksTrapdoor.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/blocks/SprucePlanksTrapdoor.java
@@ -1,18 +1,17 @@
 package com.deku.cherryblossomgrotto.common.blocks;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.TrapDoorBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockSetType;
 import net.minecraft.world.level.material.Material;
 
 public class SprucePlanksTrapdoor extends TrapDoorBlock {
     public SprucePlanksTrapdoor() {
-        super(Properties.of(Material.WOOD, Blocks.SPRUCE_PLANKS.defaultMaterialColor()).strength( 3.0f).sound(SoundType.WOOD).noOcclusion().isValidSpawn(SprucePlanksTrapdoor::never), SoundEvents.WOODEN_TRAPDOOR_CLOSE, SoundEvents.WOODEN_TRAPDOOR_OPEN);
+        super(Properties.of(Material.WOOD, Blocks.SPRUCE_PLANKS.defaultMaterialColor()).strength( 3.0f).noOcclusion().isValidSpawn(SprucePlanksTrapdoor::never), BlockSetType.SPRUCE);
     }
 
     /**

--- a/src/main/java/com/deku/cherryblossomgrotto/common/blocks/StoneTrapdoor.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/blocks/StoneTrapdoor.java
@@ -1,19 +1,18 @@
 package com.deku.cherryblossomgrotto.common.blocks;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.TrapDoorBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockSetType;
 import net.minecraft.world.level.material.Material;
 
 public class StoneTrapdoor extends TrapDoorBlock {
     public StoneTrapdoor() {
-        super(BlockBehaviour.Properties.of(Material.STONE, Blocks.STONE.defaultMaterialColor()).strength(6.0f).sound(SoundType.STONE).noOcclusion().isValidSpawn(StoneTrapdoor::never), SoundEvents.WOODEN_TRAPDOOR_CLOSE, SoundEvents.WOODEN_TRAPDOOR_OPEN);
+        super(BlockBehaviour.Properties.of(Material.STONE, Blocks.STONE.defaultMaterialColor()).strength(6.0f).noOcclusion().isValidSpawn(StoneTrapdoor::never), BlockSetType.STONE);
     }
 
     /**

--- a/src/main/java/com/deku/cherryblossomgrotto/common/blocks/cherry_blossom/CherryBlossomButton.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/blocks/cherry_blossom/CherryBlossomButton.java
@@ -1,13 +1,12 @@
 package com.deku.cherryblossomgrotto.common.blocks.cherry_blossom;
 
-import net.minecraft.sounds.SoundEvents;
+import com.deku.cherryblossomgrotto.common.blocks.ModBlockSetType;
 import net.minecraft.world.level.block.ButtonBlock;
-import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.material.Material;
 
 public class CherryBlossomButton extends ButtonBlock {
     public CherryBlossomButton() {
-        super(BlockBehaviour.Properties.of(Material.DECORATION).noCollission().strength(0.5f).sound(SoundType.WOOD), 30, true, SoundEvents.WOODEN_BUTTON_CLICK_OFF, SoundEvents.WOODEN_BUTTON_CLICK_ON);
+        super(BlockBehaviour.Properties.of(Material.DECORATION).noCollission().strength(0.5f), ModBlockSetType.CHERRY_BLOSSOM, 30, true);
     }
 }

--- a/src/main/java/com/deku/cherryblossomgrotto/common/blocks/cherry_blossom/CherryBlossomDoor.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/blocks/cherry_blossom/CherryBlossomDoor.java
@@ -1,7 +1,7 @@
 package com.deku.cherryblossomgrotto.common.blocks.cherry_blossom;
 
+import com.deku.cherryblossomgrotto.common.blocks.ModBlockSetType;
 import net.minecraft.core.BlockPos;
-import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.DoorBlock;
@@ -14,7 +14,7 @@ import net.minecraft.world.level.material.MaterialColor;
 public class CherryBlossomDoor extends DoorBlock
 {
     public CherryBlossomDoor() {
-        super(BlockBehaviour.Properties.of(Material.WOOD, MaterialColor.TERRACOTTA_RED).strength(3.0f).sound(SoundType.WOOD).noOcclusion().isValidSpawn(CherryBlossomDoor::never), SoundEvents.WOODEN_DOOR_CLOSE, SoundEvents.WOODEN_DOOR_OPEN);
+        super(BlockBehaviour.Properties.of(Material.WOOD, MaterialColor.TERRACOTTA_RED).strength(3.0f).sound(SoundType.WOOD).noOcclusion().isValidSpawn(CherryBlossomDoor::never), ModBlockSetType.CHERRY_BLOSSOM);
     }
 
     /**

--- a/src/main/java/com/deku/cherryblossomgrotto/common/blocks/cherry_blossom/CherryBlossomFenceGate.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/blocks/cherry_blossom/CherryBlossomFenceGate.java
@@ -1,6 +1,6 @@
 package com.deku.cherryblossomgrotto.common.blocks.cherry_blossom;
 
-import net.minecraft.sounds.SoundEvents;
+import com.deku.cherryblossomgrotto.common.blocks.ModWoodType;
 import net.minecraft.world.level.block.FenceGateBlock;
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.state.BlockBehaviour;
@@ -9,6 +9,6 @@ import net.minecraft.world.level.material.MaterialColor;
 
 public class CherryBlossomFenceGate extends FenceGateBlock {
     public CherryBlossomFenceGate() {
-        super(BlockBehaviour.Properties.of(Material.WOOD, MaterialColor.TERRACOTTA_RED).strength(2.0f, 3.0f).sound(SoundType.WOOD), SoundEvents.FENCE_GATE_CLOSE, SoundEvents.FENCE_GATE_OPEN);
+        super(BlockBehaviour.Properties.of(Material.WOOD, MaterialColor.TERRACOTTA_RED).strength(2.0f, 3.0f).sound(SoundType.WOOD), ModWoodType.CHERRY_BLOSSOM);
     }
 }

--- a/src/main/java/com/deku/cherryblossomgrotto/common/blocks/cherry_blossom/CherryBlossomPlanksTrapdoor.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/blocks/cherry_blossom/CherryBlossomPlanksTrapdoor.java
@@ -1,10 +1,9 @@
 package com.deku.cherryblossomgrotto.common.blocks.cherry_blossom;
 
+import com.deku.cherryblossomgrotto.common.blocks.ModBlockSetType;
 import net.minecraft.core.BlockPos;
-import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.BlockGetter;
-import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.TrapDoorBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Material;
@@ -12,7 +11,7 @@ import net.minecraft.world.level.material.MaterialColor;
 
 public class CherryBlossomPlanksTrapdoor extends TrapDoorBlock {
     public CherryBlossomPlanksTrapdoor() {
-        super(Properties.of(Material.WOOD, MaterialColor.TERRACOTTA_RED).strength( 3.0f).sound(SoundType.WOOD).noOcclusion().isValidSpawn(CherryBlossomPlanksTrapdoor::never), SoundEvents.WOODEN_TRAPDOOR_CLOSE, SoundEvents.WOODEN_TRAPDOOR_OPEN);
+        super(Properties.of(Material.WOOD, MaterialColor.TERRACOTTA_RED).strength( 3.0f).noOcclusion().isValidSpawn(CherryBlossomPlanksTrapdoor::never), ModBlockSetType.CHERRY_BLOSSOM);
     }
 
     /**

--- a/src/main/java/com/deku/cherryblossomgrotto/common/blocks/cherry_blossom/CherryBlossomPressurePlate.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/blocks/cherry_blossom/CherryBlossomPressurePlate.java
@@ -1,6 +1,6 @@
 package com.deku.cherryblossomgrotto.common.blocks.cherry_blossom;
 
-import net.minecraft.sounds.SoundEvents;
+import com.deku.cherryblossomgrotto.common.blocks.ModBlockSetType;
 import net.minecraft.world.level.block.PressurePlateBlock;
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.state.BlockBehaviour;
@@ -9,6 +9,6 @@ import net.minecraft.world.level.material.MaterialColor;
 
 public class CherryBlossomPressurePlate extends PressurePlateBlock {
     public CherryBlossomPressurePlate() {
-        super(PressurePlateBlock.Sensitivity.EVERYTHING, BlockBehaviour.Properties.of(Material.WOOD, MaterialColor.TERRACOTTA_RED).noCollission().strength(0.5F).sound(SoundType.WOOD), SoundEvents.WOODEN_PRESSURE_PLATE_CLICK_OFF, SoundEvents.WOODEN_PRESSURE_PLATE_CLICK_ON);
+        super(PressurePlateBlock.Sensitivity.EVERYTHING, BlockBehaviour.Properties.of(Material.WOOD, MaterialColor.TERRACOTTA_RED).noCollission().strength(0.5F).sound(SoundType.WOOD), ModBlockSetType.CHERRY_BLOSSOM);
     }
 }

--- a/src/main/java/com/deku/cherryblossomgrotto/common/blocks/cherry_blossom/CherryBlossomTrapDoor.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/blocks/cherry_blossom/CherryBlossomTrapDoor.java
@@ -1,10 +1,9 @@
 package com.deku.cherryblossomgrotto.common.blocks.cherry_blossom;
 
+import com.deku.cherryblossomgrotto.common.blocks.ModBlockSetType;
 import net.minecraft.core.BlockPos;
-import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.BlockGetter;
-import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.TrapDoorBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Material;
@@ -12,7 +11,7 @@ import net.minecraft.world.level.material.MaterialColor;
 
 public class CherryBlossomTrapDoor extends TrapDoorBlock {
     public CherryBlossomTrapDoor() {
-        super(Properties.of(Material.WOOD, MaterialColor.TERRACOTTA_RED).strength( 3.0f).sound(SoundType.WOOD).noOcclusion().isValidSpawn(CherryBlossomTrapDoor::never), SoundEvents.WOODEN_TRAPDOOR_CLOSE, SoundEvents.WOODEN_TRAPDOOR_OPEN);
+        super(Properties.of(Material.WOOD, MaterialColor.TERRACOTTA_RED).strength( 3.0f).noOcclusion().isValidSpawn(CherryBlossomTrapDoor::never), ModBlockSetType.CHERRY_BLOSSOM);
     }
 
     /**

--- a/src/main/java/com/deku/cherryblossomgrotto/common/blocks/maple/MapleButton.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/blocks/maple/MapleButton.java
@@ -1,12 +1,11 @@
 package com.deku.cherryblossomgrotto.common.blocks.maple;
 
-import net.minecraft.sounds.SoundEvents;
+import com.deku.cherryblossomgrotto.common.blocks.ModBlockSetType;
 import net.minecraft.world.level.block.ButtonBlock;
-import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.material.Material;
 
 public class MapleButton extends ButtonBlock {
     public MapleButton() {
-        super(Properties.of(Material.DECORATION).noCollission().strength(0.5f).sound(SoundType.WOOD), 30, true, SoundEvents.WOODEN_BUTTON_CLICK_OFF, SoundEvents.WOODEN_BUTTON_CLICK_ON);
+        super(Properties.of(Material.DECORATION).noCollission().strength(0.5f), ModBlockSetType.MAPLE, 30, true);
     }
 }

--- a/src/main/java/com/deku/cherryblossomgrotto/common/blocks/maple/MapleDoor.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/blocks/maple/MapleDoor.java
@@ -1,11 +1,10 @@
 package com.deku.cherryblossomgrotto.common.blocks.maple;
 
+import com.deku.cherryblossomgrotto.common.blocks.ModBlockSetType;
 import net.minecraft.core.BlockPos;
-import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.DoorBlock;
-import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Material;
 import net.minecraft.world.level.material.MaterialColor;
@@ -13,7 +12,7 @@ import net.minecraft.world.level.material.MaterialColor;
 public class MapleDoor extends DoorBlock
 {
     public MapleDoor() {
-        super(Properties.of(Material.WOOD, MaterialColor.WOOD).strength(3.0f).sound(SoundType.WOOD).noOcclusion().isValidSpawn(MapleDoor::never), SoundEvents.WOODEN_DOOR_CLOSE, SoundEvents.WOODEN_DOOR_OPEN);
+        super(Properties.of(Material.WOOD, MaterialColor.WOOD).strength(3.0f).noOcclusion().isValidSpawn(MapleDoor::never), ModBlockSetType.MAPLE);
     }
 
     /**

--- a/src/main/java/com/deku/cherryblossomgrotto/common/blocks/maple/MapleFenceGate.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/blocks/maple/MapleFenceGate.java
@@ -1,6 +1,6 @@
 package com.deku.cherryblossomgrotto.common.blocks.maple;
 
-import net.minecraft.sounds.SoundEvents;
+import com.deku.cherryblossomgrotto.common.blocks.ModWoodType;
 import net.minecraft.world.level.block.FenceGateBlock;
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.material.Material;
@@ -8,6 +8,6 @@ import net.minecraft.world.level.material.MaterialColor;
 
 public class MapleFenceGate extends FenceGateBlock {
     public MapleFenceGate() {
-        super(Properties.of(Material.WOOD, MaterialColor.WOOD).strength(2.0f, 3.0f).sound(SoundType.WOOD), SoundEvents.FENCE_GATE_CLOSE, SoundEvents.FENCE_GATE_OPEN);
+        super(Properties.of(Material.WOOD, MaterialColor.WOOD).strength(2.0f, 3.0f).sound(SoundType.WOOD), ModWoodType.CHERRY_BLOSSOM);
     }
 }

--- a/src/main/java/com/deku/cherryblossomgrotto/common/blocks/maple/MaplePlanksTrapdoor.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/blocks/maple/MaplePlanksTrapdoor.java
@@ -1,10 +1,9 @@
 package com.deku.cherryblossomgrotto.common.blocks.maple;
 
+import com.deku.cherryblossomgrotto.common.blocks.ModBlockSetType;
 import net.minecraft.core.BlockPos;
-import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.BlockGetter;
-import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.TrapDoorBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Material;
@@ -12,7 +11,7 @@ import net.minecraft.world.level.material.MaterialColor;
 
 public class MaplePlanksTrapdoor extends TrapDoorBlock {
     public MaplePlanksTrapdoor() {
-        super(Properties.of(Material.WOOD, MaterialColor.WOOD).strength( 3.0f).sound(SoundType.WOOD).noOcclusion().isValidSpawn(MaplePlanksTrapdoor::never), SoundEvents.WOODEN_TRAPDOOR_CLOSE, SoundEvents.WOODEN_TRAPDOOR_OPEN);
+        super(Properties.of(Material.WOOD, MaterialColor.WOOD).strength( 3.0f).noOcclusion().isValidSpawn(MaplePlanksTrapdoor::never), ModBlockSetType.MAPLE);
     }
 
     /**

--- a/src/main/java/com/deku/cherryblossomgrotto/common/blocks/maple/MaplePressurePlate.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/blocks/maple/MaplePressurePlate.java
@@ -1,13 +1,12 @@
 package com.deku.cherryblossomgrotto.common.blocks.maple;
 
-import net.minecraft.sounds.SoundEvents;
+import com.deku.cherryblossomgrotto.common.blocks.ModBlockSetType;
 import net.minecraft.world.level.block.PressurePlateBlock;
-import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.material.Material;
 import net.minecraft.world.level.material.MaterialColor;
 
 public class MaplePressurePlate extends PressurePlateBlock {
     public MaplePressurePlate() {
-        super(Sensitivity.EVERYTHING, Properties.of(Material.WOOD, MaterialColor.WOOD).noCollission().strength(0.5F).sound(SoundType.WOOD), SoundEvents.WOODEN_PRESSURE_PLATE_CLICK_OFF, SoundEvents.WOODEN_PRESSURE_PLATE_CLICK_ON);
+        super(Sensitivity.EVERYTHING, Properties.of(Material.WOOD, MaterialColor.WOOD).noCollission().strength(0.5F), ModBlockSetType.MAPLE);
     }
 }

--- a/src/main/java/com/deku/cherryblossomgrotto/common/blocks/maple/MapleTrapDoor.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/blocks/maple/MapleTrapDoor.java
@@ -1,10 +1,9 @@
 package com.deku.cherryblossomgrotto.common.blocks.maple;
 
+import com.deku.cherryblossomgrotto.common.blocks.ModBlockSetType;
 import net.minecraft.core.BlockPos;
-import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.BlockGetter;
-import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.TrapDoorBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Material;
@@ -12,7 +11,7 @@ import net.minecraft.world.level.material.MaterialColor;
 
 public class MapleTrapDoor extends TrapDoorBlock {
     public MapleTrapDoor() {
-        super(Properties.of(Material.WOOD, MaterialColor.WOOD).strength( 3.0f).sound(SoundType.WOOD).noOcclusion().isValidSpawn(MapleTrapDoor::never), SoundEvents.WOODEN_TRAPDOOR_CLOSE, SoundEvents.WOODEN_TRAPDOOR_OPEN);
+        super(Properties.of(Material.WOOD, MaterialColor.WOOD).strength( 3.0f).noOcclusion().isValidSpawn(MapleTrapDoor::never), ModBlockSetType.MAPLE);
     }
 
     /**

--- a/src/main/java/com/deku/cherryblossomgrotto/common/enchantments/DoubleJumpEnchantment.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/enchantments/DoubleJumpEnchantment.java
@@ -19,7 +19,7 @@ public class DoubleJumpEnchantment extends Enchantment {
      */
     @Override
     public boolean canEnchant(ItemStack itemStack) {
-        return itemStack.getItem() instanceof ArmorItem && ((ArmorItem)itemStack.getItem()).getSlot() == EquipmentSlot.FEET;
+        return itemStack.getItem() instanceof ArmorItem && ((ArmorItem)itemStack.getItem()).getEquipmentSlot() == EquipmentSlot.FEET;
     }
     /**
      * Whether this enchantment can only be found in treasure

--- a/src/main/java/com/deku/cherryblossomgrotto/common/items/AbstractBoatItem.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/items/AbstractBoatItem.java
@@ -2,7 +2,6 @@ package com.deku.cherryblossomgrotto.common.items;
 
 import com.deku.cherryblossomgrotto.common.entity.vehicle.ModBoatEntity;
 import com.deku.cherryblossomgrotto.common.entity.vehicle.ModBoatTypes;
-import net.minecraft.core.BlockPos;
 import net.minecraft.stats.Stats;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResultHolder;
@@ -18,6 +17,7 @@ import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -61,11 +61,9 @@ public abstract class AbstractBoatItem extends Item {
             {
                 Vec3 eyePosition = player.getEyePosition(1.0F);
 
-                for (Entity entity : entityList)
-                {
-                    AABB entityBoundingBox = entity.getBoundingBox().inflate(entity.getPickRadius());
-                    if (entityBoundingBox.contains(eyePosition))
-                    {
+                for (Entity entity : entityList) {
+                    AABB aabb = entity.getBoundingBox().inflate(entity.getPickRadius());
+                    if (aabb.contains(eyePosition)) {
                         return InteractionResultHolder.pass(itemStack);
                     }
                 }
@@ -85,7 +83,7 @@ public abstract class AbstractBoatItem extends Item {
                     if (!level.isClientSide)
                     {
                         level.addFreshEntity(boat);
-                        level.gameEvent(player, GameEvent.ENTITY_PLACE, new BlockPos(rayTraceResult.getLocation()));
+                        level.gameEvent(player, GameEvent.ENTITY_PLACE, rayTraceResult.getLocation());
                         if (!player.getAbilities().instabuild) {
                             itemStack.shrink(1);
                         }

--- a/src/main/java/com/deku/cherryblossomgrotto/common/items/AbstractChestBoatItem.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/items/AbstractChestBoatItem.java
@@ -18,6 +18,7 @@ import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -61,11 +62,9 @@ public abstract class AbstractChestBoatItem extends Item {
             {
                 Vec3 eyePosition = player.getEyePosition(1.0F);
 
-                for (Entity entity : entityList)
-                {
-                    AABB entityBoundingBox = entity.getBoundingBox().inflate(entity.getPickRadius());
-                    if (entityBoundingBox.contains(eyePosition))
-                    {
+                for (Entity entity : entityList) {
+                    AABB aabb = entity.getBoundingBox().inflate(entity.getPickRadius());
+                    if (aabb.contains(eyePosition)) {
                         return InteractionResultHolder.pass(itemStack);
                     }
                 }
@@ -85,7 +84,7 @@ public abstract class AbstractChestBoatItem extends Item {
                     if (!level.isClientSide)
                     {
                         level.addFreshEntity(boat);
-                        level.gameEvent(player, GameEvent.ENTITY_PLACE, new BlockPos(rayTraceResult.getLocation()));
+                        level.gameEvent(player, GameEvent.ENTITY_PLACE, rayTraceResult.getLocation());
                         if (!player.getAbilities().instabuild) {
                             itemStack.shrink(1);
                         }

--- a/src/main/java/com/deku/cherryblossomgrotto/common/items/KabutoCuirass.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/items/KabutoCuirass.java
@@ -13,7 +13,7 @@ import java.util.function.Consumer;
 
 public class KabutoCuirass extends ArmorItem {
     public KabutoCuirass() {
-        super(ArmorMaterials.IRON, EquipmentSlot.CHEST, new Properties().stacksTo(1));
+        super(ArmorMaterials.IRON, Type.CHESTPLATE, new Properties().stacksTo(1));
     }
 
     /**

--- a/src/main/java/com/deku/cherryblossomgrotto/common/items/KabutoGreaves.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/items/KabutoGreaves.java
@@ -15,7 +15,7 @@ import java.util.function.Consumer;
 
 public class KabutoGreaves extends ArmorItem {
     public KabutoGreaves() {
-        super(ArmorMaterials.IRON, EquipmentSlot.LEGS, new Properties().stacksTo(1));
+        super(ArmorMaterials.IRON, Type.LEGGINGS, new Properties().stacksTo(1));
     }
 
     /**

--- a/src/main/java/com/deku/cherryblossomgrotto/common/items/KabutoHelmet.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/items/KabutoHelmet.java
@@ -15,7 +15,7 @@ import java.util.function.Consumer;
 
 public class KabutoHelmet extends ArmorItem {
     public KabutoHelmet() {
-        super(ArmorMaterials.IRON, EquipmentSlot.HEAD, new Properties().stacksTo(1));
+        super(ArmorMaterials.IRON, Type.HELMET, new Properties().stacksTo(1));
     }
 
     /**

--- a/src/main/java/com/deku/cherryblossomgrotto/common/items/KabutoSandals.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/items/KabutoSandals.java
@@ -15,7 +15,7 @@ import java.util.function.Consumer;
 
 public class KabutoSandals extends ArmorItem {
     public KabutoSandals() {
-        super(ArmorMaterials.IRON, EquipmentSlot.FEET, new Properties().stacksTo(1));
+        super(ArmorMaterials.IRON, Type.BOOTS, new Properties().stacksTo(1));
     }
 
     /**

--- a/src/main/java/com/deku/cherryblossomgrotto/common/items/ModArmorMaterials.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/items/ModArmorMaterials.java
@@ -1,36 +1,52 @@
 package com.deku.cherryblossomgrotto.common.items;
 
 import com.deku.cherryblossomgrotto.Main;
+import net.minecraft.Util;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.item.ArmorItem;
 import net.minecraft.world.item.ArmorMaterial;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.level.ItemLike;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
+import java.util.EnumMap;
 import java.util.function.Supplier;
 
 public enum ModArmorMaterials implements ArmorMaterial {
-    WOOL("wool", 4, new int[] {1, 1, 1, 1}, 20, SoundEvents.ARMOR_EQUIP_LEATHER, 0.0F, 0.0F, () -> {
+    WOOL("wool", 4, Util.make(new EnumMap(ArmorItem.Type.class), (map) -> {
+        map.put(ArmorItem.Type.BOOTS, 1);
+        map.put(ArmorItem.Type.LEGGINGS, 1);
+        map.put(ArmorItem.Type.CHESTPLATE, 1);
+        map.put(ArmorItem.Type.HELMET, 1);
+    }), 20, SoundEvents.ARMOR_EQUIP_LEATHER, 0.0F, 0.0F, () -> {
         return Ingredient.of(Items.BLACK_WOOL);
     });
 
-    private static final int[] HEALTH_PER_SLOT = new int[]{13, 15, 16, 11};
+    // NOTE: Copied from vanilla ArmourMaterials
+    private static final EnumMap HEALTH_FUNCTION_FOR_TYPE = Util.make(new EnumMap(ArmorItem.Type.class), (map) -> {
+        map.put(ArmorItem.Type.BOOTS, 13);
+        map.put(ArmorItem.Type.LEGGINGS, 15);
+        map.put(ArmorItem.Type.CHESTPLATE, 16);
+        map.put(ArmorItem.Type.HELMET, 11);
+    });
+
     private final String name;
     private final int durabilityMultiplier;
-    private final int[] slotProtections;
+    private final EnumMap<ArmorItem.Type, Integer> protectionFunctionForType;
     private final int enchantmentValue;
     private final SoundEvent sound;
     private final float toughness;
     private final float knockbackResistance;
     private final Ingredient repairIngredient;
 
-    ModArmorMaterials(String name, int durabilityMultiplier, int[] slotProtections, int enchantmentValue, SoundEvent sound, float toughness, float knockbackResistance, Supplier<Ingredient> repairIngredient) {
+    ModArmorMaterials(String name, int durabilityMultiplier, EnumMap protections, int enchantmentValue, SoundEvent sound, float toughness, float knockbackResistance, Supplier<Ingredient> repairIngredient) {
         this.name = name;
         this.durabilityMultiplier = durabilityMultiplier;
-        this.slotProtections = slotProtections;
+        this.protectionFunctionForType = protections;
         this.enchantmentValue = enchantmentValue;
         this.sound = sound;
         this.toughness = toughness;
@@ -43,24 +59,24 @@ public enum ModArmorMaterials implements ArmorMaterial {
      * This is a combination of the health of each slot (a constant array inherited from the base game's
      * armour material class) and a durability multiplier.
      *
-     * @param slotType The type of slot that this armour piece is intended to be equipped in
+     * @param type The type of slot that this armour piece is intended to be equipped in
      * @return The durability of this piece of armour
      */
     @Override
-    public int getDurabilityForSlot(EquipmentSlot slotType) {
-        return HEALTH_PER_SLOT[slotType.getIndex()] * this.durabilityMultiplier;
+    public int getDurabilityForType(ArmorItem.Type type) {
+        return (Integer) HEALTH_FUNCTION_FOR_TYPE.get(type) * this.durabilityMultiplier;
     }
 
     /**
      * Gets the defense provided by wearing a piece of this armour in the given slot.
      * Read from the slot protections array specified in the enum definition.
      *
-     * @param slotType the type of slot that this armour piece is intended to be equipped in
-     * @return
+     * @param type the type of slot that this armour piece is intended to be equipped in
+     * @return Defense granted by this piece of armour
      */
     @Override
-    public int getDefenseForSlot(EquipmentSlot slotType) {
-        return this.slotProtections[slotType.getIndex()];
+    public int getDefenseForType(ArmorItem.Type type) {
+        return protectionFunctionForType.get(type);
     }
 
     /**

--- a/src/main/java/com/deku/cherryblossomgrotto/common/items/ModItems.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/items/ModItems.java
@@ -242,6 +242,9 @@ public class ModItems {
     @ObjectHolder(registryName = "minecraft:item", value = MOD_ID + ":mangrove_planks_trapdoor")
     public static BlockItem MANGROVE_PLANKS_TRAP_DOOR;
 
+    @ObjectHolder(registryName = "minecraft:item", value = MOD_ID + ":bamboo_planks_trapdoor")
+    public static BlockItem BAMBOO_PLANKS_TRAP_DOOR;
+
     @ObjectHolder(registryName = "minecraft:item", value = MOD_ID + ":smooth_stone_trapdoor")
     public static BlockItem SMOOTH_STONE_TRAP_DOOR;
 

--- a/src/main/java/com/deku/cherryblossomgrotto/common/items/NinjaLeggings.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/items/NinjaLeggings.java
@@ -15,7 +15,7 @@ import java.util.function.Consumer;
 
 public class NinjaLeggings extends ArmorItem {
     public NinjaLeggings() {
-        super(ModArmorMaterials.WOOL, EquipmentSlot.LEGS, new Item.Properties().stacksTo(1));
+        super(ModArmorMaterials.WOOL, Type.LEGGINGS, new Item.Properties().stacksTo(1));
     }
 
     /**

--- a/src/main/java/com/deku/cherryblossomgrotto/common/items/NinjaMask.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/items/NinjaMask.java
@@ -15,7 +15,7 @@ import java.util.function.Consumer;
 
 public class NinjaMask extends ArmorItem {
     public NinjaMask() {
-        super(ModArmorMaterials.WOOL, EquipmentSlot.HEAD, new Item.Properties().stacksTo(1));
+        super(ModArmorMaterials.WOOL, Type.HELMET, new Item.Properties().stacksTo(1));
     }
 
     /**

--- a/src/main/java/com/deku/cherryblossomgrotto/common/items/NinjaSandals.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/items/NinjaSandals.java
@@ -15,7 +15,7 @@ import java.util.function.Consumer;
 
 public class NinjaSandals extends ArmorItem {
     public NinjaSandals() {
-        super(ModArmorMaterials.WOOL, EquipmentSlot.FEET, new Item.Properties().stacksTo(1));
+        super(ModArmorMaterials.WOOL, Type.BOOTS, new Item.Properties().stacksTo(1));
     }
 
     /**

--- a/src/main/java/com/deku/cherryblossomgrotto/common/items/NinjaTunic.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/items/NinjaTunic.java
@@ -15,7 +15,7 @@ import java.util.function.Consumer;
 
 public class NinjaTunic extends ArmorItem {
     public NinjaTunic() {
-        super(ModArmorMaterials.WOOL, EquipmentSlot.CHEST, new Item.Properties().stacksTo(1));
+        super(ModArmorMaterials.WOOL, Type.CHESTPLATE, new Item.Properties().stacksTo(1));
     }
 
     /**

--- a/src/main/java/com/deku/cherryblossomgrotto/common/recipes/FoldingRecipe.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/recipes/FoldingRecipe.java
@@ -3,6 +3,7 @@ package com.deku.cherryblossomgrotto.common.recipes;
 import com.deku.cherryblossomgrotto.common.items.ModItems;
 import com.deku.cherryblossomgrotto.utils.ModConfiguration;
 import com.google.common.collect.Lists;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.inventory.CraftingContainer;
@@ -95,10 +96,11 @@ public class FoldingRecipe extends CustomRecipe {
      * Exits early if the katana or ingot global variables aren't assigned (which occurs during recipe matching)
      *
      * @param craftingInventory The crafting menu and inventory the katana is being assembled within
+     * @param registryAccess The accessor for registries
      * @return The instance of the Katana with NBT data saved that will build our result
      */
     @Override
-    public ItemStack assemble(CraftingContainer craftingInventory) {
+    public ItemStack assemble(CraftingContainer craftingInventory, RegistryAccess registryAccess) {
         if (katana == null || ingot == null) {
             return ItemStack.EMPTY;
         }

--- a/src/main/java/com/deku/cherryblossomgrotto/common/world/gen/foliagePlacers/CherryBlossomFoliagePlacer.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/world/gen/foliagePlacers/CherryBlossomFoliagePlacer.java
@@ -39,7 +39,7 @@ public class CherryBlossomFoliagePlacer extends FoliagePlacer {
      * The following rows will overwrite each other with a low radius as the top of the tree if foliage height is low.
      *
      * @param levelReader Reader for the level the foliage is being generated in
-     * @param blockConsumer Consumer for block position and state
+     * @param foliageSetter Setter for block position and state
      * @param random A random number generator
      * @param treeConfig Configuration class for getting the state of the placed blocks
      * @param trunkLength Length of the current tree's trunk
@@ -49,14 +49,14 @@ public class CherryBlossomFoliagePlacer extends FoliagePlacer {
      * @param offsetY The offset on the Y-axis to start the placement position
      */
     @Override
-    protected void createFoliage(LevelSimulatedReader levelReader, BiConsumer<BlockPos, BlockState> blockConsumer, RandomSource random, TreeConfiguration treeConfig, int trunkLength, FoliagePlacer.FoliageAttachment foliage, int foliageHeight, int foliageRadius, int offsetY) {
+    protected void createFoliage(LevelSimulatedReader levelReader, FoliagePlacer.FoliageSetter foliageSetter, RandomSource random, TreeConfiguration treeConfig, int trunkLength, FoliagePlacer.FoliageAttachment foliage, int foliageHeight, int foliageRadius, int offsetY) {
         boolean isDoubleTrunk = foliage.doubleTrunk();
         BlockPos foliageStartPosition = foliage.pos().above(offsetY);
-        this.placeLeavesRow(levelReader, blockConsumer, random, treeConfig, foliageStartPosition, foliageRadius + foliage.radiusOffset(), -1 - foliageHeight, isDoubleTrunk);
-        this.placeLeavesRow(levelReader, blockConsumer, random, treeConfig, foliageStartPosition, foliageRadius - 1, -foliageHeight, isDoubleTrunk);
+        this.placeLeavesRow(levelReader, foliageSetter, random, treeConfig, foliageStartPosition, foliageRadius + foliage.radiusOffset(), -1 - foliageHeight, isDoubleTrunk);
+        this.placeLeavesRow(levelReader, foliageSetter, random, treeConfig, foliageStartPosition, foliageRadius - 1, -foliageHeight, isDoubleTrunk);
 
         if (random.nextInt(2) == 1) {
-            this.placeLeavesRow(levelReader, blockConsumer, random, treeConfig, foliageStartPosition, foliageRadius + foliage.radiusOffset() - 1, -2 - foliageHeight, isDoubleTrunk);
+            this.placeLeavesRow(levelReader, foliageSetter, random, treeConfig, foliageStartPosition, foliageRadius + foliage.radiusOffset() - 1, -2 - foliageHeight, isDoubleTrunk);
         }
     }
 

--- a/src/main/java/com/deku/cherryblossomgrotto/common/world/gen/foliagePlacers/GrandCherryBlossomFoliagePlacer.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/world/gen/foliagePlacers/GrandCherryBlossomFoliagePlacer.java
@@ -40,7 +40,7 @@ public class GrandCherryBlossomFoliagePlacer extends FoliagePlacer {
      * The following rows will overwrite each other with a low radius as the top of the tree if foliage height is low.
      *
      * @param levelReader Reader for the level the foliage is being generated in
-     * @param blockConsumer Consumer for block position and state
+     * @param foliageSetter Setter for block position and state
      * @param random A random number generator
      * @param treeConfig Configuration class for getting the state of the placed blocks
      * @param trunkLength Length of the current tree's trunk
@@ -50,23 +50,23 @@ public class GrandCherryBlossomFoliagePlacer extends FoliagePlacer {
      * @param offsetY The offset on the Y-axis to start the placement position
      */
     @Override
-    protected void createFoliage(LevelSimulatedReader levelReader, BiConsumer<BlockPos, BlockState> blockConsumer, RandomSource random, TreeConfiguration treeConfig, int trunkLength, FoliagePlacer.FoliageAttachment foliage, int foliageHeight, int foliageRadius, int offsetY) {
+    protected void createFoliage(LevelSimulatedReader levelReader, FoliagePlacer.FoliageSetter foliageSetter, RandomSource random, TreeConfiguration treeConfig, int trunkLength, FoliagePlacer.FoliageAttachment foliage, int foliageHeight, int foliageRadius, int offsetY) {
         if (foliage.doubleTrunk()) {
             // Places the base row which is a cross of leaves and at the top level of logs
-            this.placeLeavesRow(levelReader, blockConsumer, random, treeConfig, foliage.pos(), foliageRadius - 2, -1, true);
+            this.placeLeavesRow(levelReader, foliageSetter, random, treeConfig, foliage.pos(), foliageRadius - 2, -1, true);
 
-            generateCanopy(levelReader, blockConsumer, random, treeConfig, foliage, foliageHeight, foliageRadius);
+            generateCanopy(levelReader, foliageSetter, random, treeConfig, foliage, foliageHeight, foliageRadius);
         } else {
             foliageRadius -= 3;
 
             // top off with a small amount of leaves
-            this.placeLeavesRow(levelReader, blockConsumer, random, treeConfig, foliage.pos(), 1, 1, false);
+            this.placeLeavesRow(levelReader, foliageSetter, random, treeConfig, foliage.pos(), 1, 1, false);
 
             // Places the base row which is a cross of leaves and at the top level of logs
-            this.placeLeavesRow(levelReader, blockConsumer, random, treeConfig, foliage.pos(), foliageRadius, 0, false);
+            this.placeLeavesRow(levelReader, foliageSetter, random, treeConfig, foliage.pos(), foliageRadius, 0, false);
 
             // bottom out with a single block of leaves to cover the source log
-            this.placeLeavesRow(levelReader, blockConsumer, random, treeConfig, foliage.pos(), 0, -1, false);
+            this.placeLeavesRow(levelReader, foliageSetter, random, treeConfig, foliage.pos(), 0, -1, false);
         }
     }
 
@@ -74,17 +74,17 @@ public class GrandCherryBlossomFoliagePlacer extends FoliagePlacer {
      * Places foliage in a typical canopy shape by looping through all height levels for the leave generation and making individual rows one after the other with a degrading radius value.
      *
      * @param levelReader Reader for the level the foliage is being generated in
-     * @param blockConsumer Consumer for block position and state
+     * @param foliageSetter Setter for block position and state
      * @param random A random number generator
      * @param treeConfig Configuration class for getting the state of the placed blocks
      * @param foliage Foliage settings for this foliage placer
      * @param foliageHeight Height of the foliage to be created at this foliage point
      * @param foliageRadius The radius of the foliage
      */
-    private void generateCanopy(LevelSimulatedReader levelReader, BiConsumer<BlockPos, BlockState> blockConsumer, RandomSource random, TreeConfiguration treeConfig, FoliagePlacer.FoliageAttachment foliage, int foliageHeight, int foliageRadius) {
+    private void generateCanopy(LevelSimulatedReader levelReader, FoliagePlacer.FoliageSetter foliageSetter, RandomSource random, TreeConfiguration treeConfig, FoliagePlacer.FoliageAttachment foliage, int foliageHeight, int foliageRadius) {
         for (int positionY = foliageHeight; positionY > -1; positionY--) {
             int radius = Math.max(foliageRadius + foliage.radiusOffset() - positionY, 0);
-            this.placeLeavesRow(levelReader, blockConsumer, random, treeConfig, foliage.pos(), radius, positionY, foliage.doubleTrunk());
+            this.placeLeavesRow(levelReader, foliageSetter, random, treeConfig, foliage.pos(), radius, positionY, foliage.doubleTrunk());
         }
     }
 

--- a/src/main/java/com/deku/cherryblossomgrotto/common/world/gen/trunkPlacers/GrandCherryBlossomTrunkPlacer.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/common/world/gen/trunkPlacers/GrandCherryBlossomTrunkPlacer.java
@@ -285,7 +285,7 @@ public class GrandCherryBlossomTrunkPlacer extends GiantTrunkPlacer {
             double interpolatedPositionX = Mth.lerp(current, trueStartingPosition.getX(), end.getX());
             double interpolatedPositionY = Mth.lerp(current, trueStartingPosition.getY(), end.getY());
             double interpolatedPositionZ = Mth.lerp(current, trueStartingPosition.getZ(), end.getZ());
-            BlockPos nextPosition = new BlockPos(Math.round(interpolatedPositionX), Math.round(interpolatedPositionY), Math.round(interpolatedPositionZ));
+            BlockPos nextPosition = new BlockPos((int) Math.round(interpolatedPositionX), (int) Math.round(interpolatedPositionY), (int) Math.round(interpolatedPositionZ));
             greedyPoints.add(nextPosition);
         }
 

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -15,3 +15,5 @@ public net.minecraft.world.entity.npc.VillagerTrades$EmeraldsForVillagerTypeItem
 public-f net.minecraft.world.entity.npc.VillagerTrades$EmeraldsForVillagerTypeItem f_35664_ # trades
 
 public net.minecraft.world.level.levelgen.feature.trunkplacers.TrunkPlacerType <init>(Lcom/mojang/serialization/Codec;)V # constructor
+
+public net.minecraft.world.level.block.state.properties.BlockSetType m_272115_(Lnet/minecraft/world/level/block/state/properties/BlockSetType;)Lnet/minecraft/world/level/block/state/properties/BlockSetType; # register

--- a/src/main/resources/data/cherryblossomgrotto/worldgen/biome/cherry_blossom_bamboo_jungle.json
+++ b/src/main/resources/data/cherryblossomgrotto/worldgen/biome/cherry_blossom_bamboo_jungle.json
@@ -5,7 +5,7 @@
   "temperature": 0.8,
   "temperature_modifier": "none",
   "downfall": 0.9,
-  "precipitation": "rain",
+  "has_precipitation": true,
   "player_spawn_friendly": true,
   "creature_spawn_friendly": true,
   "creature_spawn_probability": 0.5,

--- a/src/main/resources/data/cherryblossomgrotto/worldgen/biome/cherry_blossom_grotto.json
+++ b/src/main/resources/data/cherryblossomgrotto/worldgen/biome/cherry_blossom_grotto.json
@@ -5,7 +5,7 @@
   "temperature": 0.8,
   "temperature_modifier": "none",
   "downfall": 0.8,
-  "precipitation": "rain",
+  "has_precipitation": true,
   "player_spawn_friendly": true,
   "creature_spawn_friendly": true,
   "creature_spawn_probability": 0.5,

--- a/src/main/resources/data/cherryblossomgrotto/worldgen/biome/cherry_blossom_slopes.json
+++ b/src/main/resources/data/cherryblossomgrotto/worldgen/biome/cherry_blossom_slopes.json
@@ -5,7 +5,7 @@
   "temperature": -0.3,
   "temperature_modifier": "none",
   "downfall": 0.9,
-  "precipitation": "snow",
+  "has_precipitation": true,
   "player_spawn_friendly": true,
   "creature_spawn_friendly": true,
   "creature_spawn_probability": 0.5,

--- a/src/main/resources/data/cherryblossomgrotto/worldgen/biome/maple_woods.json
+++ b/src/main/resources/data/cherryblossomgrotto/worldgen/biome/maple_woods.json
@@ -2,7 +2,7 @@
   "temperature": 0.7,
   "temperature_modifier": "none",
   "downfall": 0.8,
-  "precipitation": "rain",
+  "has_precipitation": true,
   "player_spawn_friendly": true,
   "creature_spawn_friendly": true,
   "creature_spawn_probability": 0.3,

--- a/src/main/resources/data/cherryblossomgrotto/worldgen/biome/oak_and_maple_forest.json
+++ b/src/main/resources/data/cherryblossomgrotto/worldgen/biome/oak_and_maple_forest.json
@@ -2,7 +2,7 @@
   "temperature": 0.7,
   "temperature_modifier": "none",
   "downfall": 0.8,
-  "precipitation": "rain",
+  "has_precipitation": true,
   "player_spawn_friendly": true,
   "creature_spawn_friendly": true,
   "creature_spawn_probability": 0.3,

--- a/src/main/resources/data/minecraft/tags/items/swords.json
+++ b/src/main/resources/data/minecraft/tags/items/swords.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "cherryblossomgrotto:katana"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/worldgen/biome/is_mountain.json
+++ b/src/main/resources/data/minecraft/tags/worldgen/biome/is_mountain.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "cherryblossomgrotto:cherry_blossom_slopes"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/worldgen/biome/spawns_snow_foxes.json
+++ b/src/main/resources/data/minecraft/tags/worldgen/biome/spawns_snow_foxes.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "cherryblossomgrotto:cherry_blossom_slopes"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/worldgen/biome/spawns_white_rabbits.json
+++ b/src/main/resources/data/minecraft/tags/worldgen/biome/spawns_white_rabbits.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "cherryblossomgrotto:cherry_blossom_slopes"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/worldgen/structure/ruined_portal.json
+++ b/src/main/resources/data/minecraft/tags/worldgen/structure/ruined_portal.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "cherryblossomgrotto:ruined_torii_portal"
+  ]
+}


### PR DESCRIPTION
General updates for 1.19.4 compatibility:

- Added feature gated bamboo planks trapdoor
- Katanas are now classified as a type of sword
- Cherry blossom slopes can now spawn white foxes and white rabbits
- Cherry blossom wood now uses the same block sets at the vanilla cherry wood coming in 1.20
- Cherry Blossom slopes biome is now correctly classified as a mountain biome
- Ruined torii portal is now correctly classified as a variant of a ruined portal structure
- General refactor to fix breaking changes from vanilla Minecraft updates