### PR TITLE
1.19.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
 apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'org.spongepowered.mixin'
 
-version = '1.5.0'
+version = '1.5.1'
 group = 'com.deku.cherryblossomgrotto' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'cherryblossomgrotto'
 

--- a/src/main/java/com/deku/cherryblossomgrotto/Main.java
+++ b/src/main/java/com/deku/cherryblossomgrotto/Main.java
@@ -920,7 +920,7 @@ public class Main
          */
         @SubscribeEvent
         public static void onBlockClicked(PlayerInteractEvent.RightClickBlock event) {
-            final Map<Block, Block> BLOCK_STRIPPING_MAP = (new ImmutableMap.Builder<Block, Block>().put(ModBlocks.CHERRY_LOG, ModBlocks.STRIPPED_CHERRY_LOG).put(ModBlocks.CHERRY_WOOD, ModBlocks.STRIPPED_CHERRY_WOOD)).build();
+            final Map<Block, Block> BLOCK_STRIPPING_MAP = (new ImmutableMap.Builder<Block, Block>().put(ModBlocks.CHERRY_LOG, ModBlocks.STRIPPED_CHERRY_LOG).put(ModBlocks.CHERRY_WOOD, ModBlocks.STRIPPED_CHERRY_WOOD).put(ModBlocks.MAPLE_LOG, ModBlocks.STRIPPED_MAPLE_LOG).put(ModBlocks.MAPLE_WOOD, ModBlocks.STRIPPED_MAPLE_WOOD)).build();
 
             if (event.getItemStack().getItem() instanceof AxeItem) {
                 net.minecraft.world.level.Level level = event.getLevel();

--- a/src/main/resources/data/cherryblossomgrotto/loot_tables/blocks/maple_leaf_pile.json
+++ b/src/main/resources/data/cherryblossomgrotto/loot_tables/blocks/maple_leaf_pile.json
@@ -39,7 +39,7 @@
                       }
                     }
                   ],
-                  "name": "cherryblossomgrotto:cherry_blossom_petal"
+                  "name": "cherryblossomgrotto:maple_leaf"
                 },
                 {
                   "type": "minecraft:item",
@@ -58,7 +58,7 @@
                       "count": 2
                     }
                   ],
-                  "name": "cherryblossomgrotto:cherry_blossom_petal"
+                  "name": "cherryblossomgrotto:maple_leaf"
                 }
               ]
             },

--- a/src/main/resources/data/cherryblossomgrotto/loot_tables/blocks/maple_leaves.json
+++ b/src/main/resources/data/cherryblossomgrotto/loot_tables/blocks/maple_leaves.json
@@ -52,7 +52,7 @@
                   "enchantment": "minecraft:fortune"
                 }
               ],
-              "name": "cherryblossomgrotto:cherry_blossom_sapling"
+              "name": "cherryblossomgrotto:maple_sapling"
             }
           ]
         }


### PR DESCRIPTION
Fixes some issues with the maple woods biome:
    - Maple logs can now be stripped with an axe
    - Maple leaf blocks can drop the right sapling type when decaying now
    - Maple leaf piles will drop maple leaf items when destroyed instead of cherry blossom leaves

